### PR TITLE
WIP: Add explore pages

### DIFF
--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -14,6 +14,7 @@ author: bkeepers
 repository: probot/dco
 topics:
 - licensing
+- code-review
 ---
 
 

--- a/_apps/duplicate-issues.md
+++ b/_apps/duplicate-issues.md
@@ -6,4 +6,7 @@ stars: 15
 installations: 4
 author: MarshallOfSound
 repository: MarshallOfSound/probot-issue-duplicate-detection
+topics:
+- community-management
+- project-management
 ---

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -9,8 +9,8 @@ installations: 13
 author: hiimbex
 repository: behaviorbot/request-info
 topics:
-- open source
-- request-more-info
+- community-management
+- project-management
 ---
 
 

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -4,6 +4,7 @@ description: Pull Requests for repository settings
 slug: settings
 topics:
 - administration
+- code-review
 stars: 123
 installations: 38
 author: bkeepers

--- a/_apps/snooze.md
+++ b/_apps/snooze.md
@@ -7,5 +7,5 @@ stars: 3
 installations: 5
 repository: jbjonesjr/probot-snooze
 topics:
-- issues
+- project-management
 ---

--- a/_apps/snooze.md
+++ b/_apps/snooze.md
@@ -6,4 +6,6 @@ author: jbjonesjr
 stars: 3
 installations: 5
 repository: jbjonesjr/probot-snooze
+topics:
+- issues
 ---

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -7,6 +7,7 @@ screenshots:
 - https://user-images.githubusercontent.com/173/27765705-93f94940-5e7e-11e7-8527-3a91bb64ca70.png
 topics:
 - project-management
+- community-management
 organizations:
 - atom
 - Homebrew

--- a/_apps/update-docs.md
+++ b/_apps/update-docs.md
@@ -11,12 +11,12 @@ installations: 94
 author: hiimbex
 repository: behaviorbot/update-docs
 topics:
-- open source
-- documentation
+- code-review
+- community-management
 ---
 
 
-Update Docs comments on newly opened Pull Requests that do not update either the README or a file in the `/docs` folder. 
+Update Docs comments on newly opened Pull Requests that do not update either the README or a file in the `/docs` folder.
 
 Create a `.github/config.yml` file that contains the contents you would like to reply within an `updateDocsComment`. Optionally, you can also add an `updateDocsWhiteList` that includes terms, that if found in the title, the bot will not comment on.
 

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -13,8 +13,7 @@ installations: 123
 author: hiimbex
 repository: behaviorbot/welcome
 topics:
-- open source
-- welcome
+- community-management
 ---
 
 
@@ -41,7 +40,7 @@ newPRWelcomeComment: >
 
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
-  Congrats on merging your first pull request! We here at behaviorbot are proud of you! 
+  Congrats on merging your first pull request! We here at behaviorbot are proud of you!
 
 # It is recommend to include as many gifs and emojis as possible
 ```

--- a/_apps/wip.md
+++ b/_apps/wip.md
@@ -6,4 +6,6 @@ author: gr2m
 stars: 5
 installations: 7
 repository: gr2m/wip-bot
+topics:
+- code-review
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,9 @@ sass:
     - node_modules/**/*/node_modules
 
 collections:
+  topics:
+    output: true
+    permalink: /apps/:name/
   apps:
     output: true
     permalink: /apps/:name/
@@ -28,6 +31,11 @@ defaults:
       type: apps
     values:
       layout: app
+  - scope:
+      path: ""
+      type: topics
+    values:
+      layout: topic
   - scope:
       path: "docs"
     values:

--- a/_includes/app.html
+++ b/_includes/app.html
@@ -1,0 +1,21 @@
+{% if include.col == 2 %}
+  {% assign classes = "col-lg-6 col-md-6" %}
+{% else %}
+  {% assign classes = "col-lg-4 col-md-6" %}
+{% endif %}
+
+<div class="{{ classes }} my-3">
+  <a href="{{ app.url }}" class="d-flex flex-column bg-white rounded-1 box-shadow border text-inherit no-underline" style="height:100%">
+    <h3 class="h4 px-3 pt-3">{{ include.app.title }}</h3>
+    <p class="text-gray lh-condensed px-3 pb-3">{{ include.app.description }}</p>
+    <div class="text-gray-light pl-3 pr-2 py-2 bg-gray-light border-top" style="margin-top: auto;">
+      <div class="d-flex flex-row">
+        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ include.app.installations }} installations">{% octicon cloud-download width:14 class:"v-align-middle" %} <span class="">{{ include.app.installations }}</span></div>
+        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ include.app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ include.app.stars }}</span></div>
+        <div class="col-6 text-right">
+          <img class="avatar tooltipped tooltipped-s" aria-label="Made by {{ include.app.author }}" height="24" src="https://github.com/{{ include.app.author }}.png">
+        </div>
+      </div>
+    </div>
+  </a>
+</div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,11 +1,15 @@
-<div class="border-bottom">
+{% if page.url == '/' %}{% assign homepage = true %}{% endif %}
+
+<div class="{% unless homepage %}border-bottom{% endunless %}">
   <div class="container-lg px-3">
     <div class="py-4 d-flex d-flex-row">
       <h1 class="alt-h4 col-4 lh-default v-align-middle">
+        {% unless homepage %}
         <a href="/" class="no-underline text-uppercase text-brand-blue-dark">
           <img class="v-align-middle" style="margin: -20px 8px -8px 0;" src="/assets/probot-head.png" height="36" alt="">
           Probot
         </a>
+        {% endunless %}
       </h1>
       <nav class="text-bold col-8 text-right">
         <a class="text-inherit px-2 d-inline-block" href="/#explore">Explore</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -12,7 +12,7 @@
         {% endunless %}
       </h1>
       <nav class="text-bold col-8 text-right">
-        <a class="text-inherit px-2 d-inline-block" href="/#explore">Explore</a>
+        <a class="text-inherit px-2 d-inline-block" href="/apps/">Explore</a>
         <a class="text-inherit px-2 d-inline-block" href="/docs/">Build</a>
         <a class="text-inherit px-2 d-inline-block" href="https://github.com/probot/probot">Contribute</a>
       </nav>

--- a/_includes/topics.html
+++ b/_includes/topics.html
@@ -1,0 +1,13 @@
+<h2 class="alt-h4 mb-2">Topics</h2>
+
+<ul class="list-style-none">
+  {% for topic in site.topics %}
+    {% if page.url == topic.url %}
+      {% assign classes = "text-brand-red" %}
+    {% else %}
+      {% assign classes = "link-gray" %}
+    {% endif %}
+
+    <li><a class="py-1 d-block {{ classes }}" href="{{ topic.url }}">{{ topic.title }}</a></li>
+  {% endfor %}
+</ul>

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -3,10 +3,11 @@ layout: default
 ---
 
 <div class="">
-  <div class="container-lg px-3 jumbotron jumbotron-minitron">
+  <div class="container-lg px-3 py-4">
     <div class="d-flex d-flex-row gutter-spacious">
       <div class="flex-column col-9">
-        <h1 class="alt-h1 lh-condensed-ultra">{{ page.title }}</h1>
+        <span class="breadcrumb-item"><a class="link-gray" href="/apps/">Explore</a></span>
+        <h1 class="alt-h2">{{ page.title }}</h1>
         <div class="text-gray-light">{{ page.description }}</div>
       </div>
       <div class="flex-column col-3 text-center">

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -2,8 +2,6 @@
 layout: default
 ---
 
-{% include nav.html %}
-
 <div class="">
   <div class="container-lg px-3 jumbotron jumbotron-minitron">
     <div class="d-flex d-flex-row gutter-spacious">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,8 @@
     {% seo %}
   </head>
   <body>
+    {% include nav.html %}
+
     {{ content }}
 
     {% include footer.html %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -2,8 +2,6 @@
 layout: default
 ---
 
-{% include nav.html %}
-
 <div class="container-lg px-3 py-6">
   <div class="d-flex flex-row gutter-spacious">
     <div id="toc" class="col-3 py-6">

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -1,0 +1,14 @@
+---
+layout: default
+---
+{% assign topic = page.path | replace: ".md", "" | replace: "_topics/", "" %}
+
+<div class="container-lg px-3">
+  <h1 class="alt-h2">{{ page.title }}</h1>
+
+  {% for app in site.apps %}
+    {% if app.topics contains topic %}
+      {% include app.html app=app %}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/_layouts/topic.html
+++ b/_layouts/topic.html
@@ -4,11 +4,22 @@ layout: default
 {% assign topic = page.path | replace: ".md", "" | replace: "_topics/", "" %}
 
 <div class="container-lg px-3">
-  <h1 class="alt-h2">{{ page.title }}</h1>
-
-  {% for app in site.apps %}
-    {% if app.topics contains topic %}
-      {% include app.html app=app %}
-    {% endif %}
-  {% endfor %}
+  <div class="jumbotron jumbotron-minitron bg-gray">
+    <span class="breadcrumb-item ml-0"><a class="link-gray" href="/apps/">Explore</a></span>
+    <h1 class="alt-h2">{{ page.title }}</h1>
+  </div>
+  <div class="d-flex flex-row-reverse">
+    <div class="col-9">
+      <div class="d-md-flex flex-wrap gutter flex-auto">
+        {% for app in site.apps %}
+          {% if app.topics contains topic %}
+            {% include app.html app=app col=2 %}
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+    <div class="col-3">
+      {% include topics.html %}
+    </div>
+  </div>
 </div>

--- a/_topics/administration.md
+++ b/_topics/administration.md
@@ -1,0 +1,3 @@
+---
+title: Administration
+---

--- a/_topics/code-review.md
+++ b/_topics/code-review.md
@@ -1,0 +1,3 @@
+---
+topic: Code Review
+---

--- a/_topics/community-management.md
+++ b/_topics/community-management.md
@@ -1,0 +1,3 @@
+---
+topic: Community Management
+---

--- a/_topics/licensing.md
+++ b/_topics/licensing.md
@@ -1,0 +1,3 @@
+---
+title: Licensing
+---

--- a/_topics/project-management.md
+++ b/_topics/project-management.md
@@ -1,0 +1,3 @@
+---
+title: Project Management
+---

--- a/apps/index.html
+++ b/apps/index.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+
+<div class="container-lg px-3 featurette">
+  <div class="d-flex flex-row-reverse">
+    <div class="col-9">
+      <div class="d-md-flex flex-wrap gutter flex-auto">
+        {% for app in site.apps limit:9 %}
+          {% include app.html app=app col=2 %}
+        {% endfor %}
+      </div>
+
+    </div>
+    <div class="col-3">
+      {% include topics.html %}
+    </div>
+  </div>
+</div>
+
+<div class="bg-gray-light border-top border-gray-light">
+  <div class="container-lg px-3">
+    <div class="offset-3">
+      List yo app, yo!
+    </div>
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -33,21 +33,7 @@ layout: default
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
       {% for app in site.apps limit:9 %}
-        <div class="col-lg-4 col-md-6 mb-3 mt-3">
-          <a href="{{ app.url }}" class="d-flex flex-column bg-white rounded-1 box-shadow border text-inherit no-underline" style="height:100%">
-            <h3 class="h4 px-3 pt-3">{{ app.title }}</h3>
-            <p class="text-gray lh-condensed px-3 pb-3">{{ app.description }}</p>
-            <div class="text-gray-light pl-3 pr-2 py-2 bg-gray-light border-top" style="margin-top: auto;">
-              <div class="d-flex flex-row">
-                <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.installations }} installations">{% octicon cloud-download width:14 class:"v-align-middle" %} <span class="">{{ app.installations }}</span></div>
-                <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ app.stars }}</span></div>
-                <div class="col-6 text-right">
-                  <img class="avatar tooltipped tooltipped-s" aria-label="Made by {{ app.author }}" height="24" src="https://github.com/{{ app.author }}.png">
-                </div>
-              </div>
-            </div>
-          </a>
-        </div>
+        {% include app.html app=app %}
       {% endfor %}
     </div>
 
@@ -55,7 +41,7 @@ layout: default
       <p class="lead mx-auto col-md-8">
         Discover dozens of apps that extend GitHub and improve your workflow.
       </p>
-      <a class="btn btn-outline btn-large" href="https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories">
+      <a class="btn btn-outline btn-large" href="/apps/">
         {% octicon telescope class:"mr-2" %}
         Explore more apps
       </a>

--- a/index.html
+++ b/index.html
@@ -2,16 +2,6 @@
 layout: default
 ---
 <div class="">
-  <div class="container-lg">
-    <div class="py-4 px-3 clearfix">
-      <nav class="text-bold d-block float-right">
-        <a class="text-inherit px-2 d-inline-block" href="/#explore">Explore</a>
-        <a class="text-inherit px-2 d-inline-block" href="/docs/">Build</a>
-        <a class="text-inherit px-2 d-inline-block" href="https://github.com/probot/probot">Contribute</a>
-      </nav>
-    </div>
-  </div>
-
   <div class="container-lg px-3">
     <header class="py-6">
       <div class="pb-0 pt-md-4 py-lg-6">


### PR DESCRIPTION
This adds an explore page at `/apps` that will list all official apps, and adds browsing by topic.

### Topics

I looked through the existing apps and attempted to categorize them. Here are the topics that seemed to make sense with the current plugins. Thoughts?

- administration
- code-review
- community-management
- licensing
- project-management

### TODO

- [ ] Get feedback on list of topics
- [ ] browse hosted apps by topic
- [ ] link to browse [all open source apps](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories)
- [ ] Add test to ensure all apps are in at least 1 topic and all topics are valid
