### PR TITLE
Cleanup apps

### DIFF
--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -4,7 +4,7 @@ description: Enforce the DCO on Pull Requests
 slug: dco
 screenshots:
 - https://cloud.githubusercontent.com/assets/173/24482273/a35dc23e-14b5-11e7-9371-fd241873e2c3.png
-stars: 19
+stars: 20
 author: bkeepers
 repository: probot/dco
 topics:

--- a/_apps/duplicate-issues.md
+++ b/_apps/duplicate-issues.md
@@ -1,8 +1,0 @@
----
-title: Duplicate Issues
-description: Automatically detects duplicate issues
-slug: dup
-stars: 15
-author: MarshallOfSound
-repository: MarshallOfSound/probot-issue-duplicate-detection
----

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -4,7 +4,7 @@ description: Requests more info on issues and pull requests with the default tit
 slug: request-info
 screenshots:
 - https://user-images.githubusercontent.com/13410355/28132821-d37bf2a8-66f2-11e7-9e7b-5930ba65d67a.png
-stars: 47
+stars: 2
 author: hiimbex
 repository: behaviorbot/request-info
 topics:

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -4,7 +4,7 @@ description: Pull Requests for repository settings
 slug: settings
 topics:
 - administration
-stars: 123
+stars: 124
 author: bkeepers
 repository: probot/settings
 ---

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -7,6 +7,8 @@ topics:
 stars: 124
 author: bkeepers
 repository: probot/settings
+screenshots:
+- https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png
 ---
 
 This GitHub App syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.

--- a/_apps/snooze.md
+++ b/_apps/snooze.md
@@ -1,8 +1,0 @@
----
-title: Snooze
-description: Temporarily close Issues and Pull Requests
-slug: snooze
-author: jbjonesjr
-stars: 3
-repository: jbjonesjr/probot-snooze
----

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -8,9 +8,8 @@ screenshots:
 topics:
 - project-management
 author: bkeepers
-stars: 129
+stars: 128
 repository: probot/stale
-host: https://probot-stale.herokuapp.com
 ---
 
 Automatically close stale Issues and Pull Requests that tend to accumulate during a project.

--- a/_apps/update-docs.md
+++ b/_apps/update-docs.md
@@ -4,7 +4,7 @@ description: Replies to newly opened pull requests that do no update a file in t
 slug: update-docs
 screenshots:
 - https://user-images.githubusercontent.com/13410355/28179044-97207bee-67b5-11e7-80d0-0c8ede4a325f.png
-stars: 47
+stars: 1
 author: hiimbex
 repository: behaviorbot/update-docs
 topics:

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -6,7 +6,7 @@ screenshots:
 - https://user-images.githubusercontent.com/13410355/28288851-679f582a-6af5-11e7-8dd8-b85b6c33e16b.png
 - https://user-images.githubusercontent.com/13410355/28288547-5f83aa8e-6af4-11e7-9692-eb41d42431e2.png
 - https://user-images.githubusercontent.com/13410355/28289605-1ab81a76-6af8-11e7-8f78-6a1b3948df36.png
-stars: 99
+stars: 5
 author: hiimbex
 repository: behaviorbot/welcome
 topics:

--- a/_apps/wip.md
+++ b/_apps/wip.md
@@ -1,8 +1,0 @@
----
-title: Work In Progress
-description: Prevent merging of unfinished Pull Requests
-slug: wip
-author: gr2m
-stars: 5
-repository: gr2m/wip-bot
----

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ layout: default
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
       {% assign apps = site.apps | sort: 'stars' | reverse %}
-      {% for app in apps limit:9 %}
+      {% for app in apps limit:6 %}
         <div class="col-lg-4 col-md-6 mb-3 mt-3">
           <a href="{{ app.url }}" class="d-flex flex-column bg-white rounded-1 box-shadow border text-inherit no-underline" style="height:100%">
             <h3 class="h4 px-3 pt-3">{{ app.title }}</h3>


### PR DESCRIPTION
- Removes apps without docs
- Limits homepage to 6 apps
- Syncs stars

Next I'll extract `/apps` from #18 so there is a listing of all apps.