### PR TITLE
Add support for multiple authors

### DIFF
--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -5,7 +5,7 @@ slug: dco
 screenshots:
 - https://cloud.githubusercontent.com/assets/173/24482273/a35dc23e-14b5-11e7-9371-fd241873e2c3.png
 stars: 22
-author: bkeepers
+authors: [ bkeepers ]
 repository: probot/dco
 updated: 2017-09-08 16:31:49 UTC
 ---

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -5,7 +5,7 @@ slug: request-info
 screenshots:
 - https://user-images.githubusercontent.com/13410355/28132821-d37bf2a8-66f2-11e7-9e7b-5930ba65d67a.png
 stars: 2
-author: hiimbex
+authors: [ hiimbex ]
 repository: behaviorbot/request-info
 updated: 2017-08-15 15:27:53 UTC
 ---

--- a/_apps/sentiment-bot.md
+++ b/_apps/sentiment-bot.md
@@ -5,7 +5,7 @@ slug: sentiment-bot
 screenshots:
 - https://user-images.githubusercontent.com/13410355/29323857-fcfe4b4e-8196-11e7-9a08-6184fd46edbb.png
 stars: 7
-author: hiimbex
+authors: [ hiimbex ]
 repository: behaviorbot/sentiment-bot
 updated: 2017-08-17 17:44:08 UTC
 ---

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -3,7 +3,7 @@ title: Settings
 description: Pull Requests for repository settings
 slug: settings
 stars: 134
-author: bkeepers
+authors: [ bkeepers ]
 repository: probot/settings
 screenshots:
 - https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -5,7 +5,7 @@ slug: stale
 screenshots:
 - https://user-images.githubusercontent.com/173/27765695-4c016050-5e7e-11e7-9016-c2f6d8c27da4.png
 - https://user-images.githubusercontent.com/173/27765705-93f94940-5e7e-11e7-8527-3a91bb64ca70.png
-author: bkeepers
+authors: [ bkeepers ]
 stars: 145
 repository: probot/stale
 updated: 2017-08-29 15:17:14 UTC

--- a/_apps/update-docs.md
+++ b/_apps/update-docs.md
@@ -5,7 +5,7 @@ slug: update-docs
 screenshots:
 - https://user-images.githubusercontent.com/13410355/28179044-97207bee-67b5-11e7-80d0-0c8ede4a325f.png
 stars: 2
-author: hiimbex
+authors: [ hiimbex ]
 repository: behaviorbot/update-docs
 updated: 2017-08-15 15:27:36 UTC
 ---

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -7,7 +7,7 @@ screenshots:
 - https://user-images.githubusercontent.com/13410355/28288547-5f83aa8e-6af4-11e7-9692-eb41d42431e2.png
 - https://user-images.githubusercontent.com/13410355/28289605-1ab81a76-6af8-11e7-8f78-6a1b3948df36.png
 stars: 7
-authors: [ hiimbex, hiimbex-test ]
+authors: [ hiimbex ]
 repository: behaviorbot/welcome
 updated: 2017-08-25 23:49:39 UTC
 ---

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -7,7 +7,7 @@ screenshots:
 - https://user-images.githubusercontent.com/13410355/28288547-5f83aa8e-6af4-11e7-9692-eb41d42431e2.png
 - https://user-images.githubusercontent.com/13410355/28289605-1ab81a76-6af8-11e7-8f78-6a1b3948df36.png
 stars: 7
-author: hiimbex
+authors: [ hiimbex, hiimbex-test ]
 repository: behaviorbot/welcome
 updated: 2017-08-25 23:49:39 UTC
 ---

--- a/_includes/app.html
+++ b/_includes/app.html
@@ -6,7 +6,9 @@
       <div class="d-flex flex-row">
         <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ app.stars }}</span></div>
         <div class="col-9 text-right">
-          <img class="avatar tooltipped tooltipped-s" alt="Made by {{ app.author }}" aria-label="Made by {{ app.author }}" height="24" src="https://github.com/{{ app.author }}.png">
+          {% for author in app.authors %}
+            <img class="avatar tooltipped tooltipped-s" alt="Made by {{ author }}" aria-label="Made by {{ author }}" height="24" src="https://github.com/{{ author }}.png">
+          {% endfor %}
         </div>
       </div>
     </div>

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -50,10 +50,12 @@ layout: default
         <p>
           <a class="text-inherit" href="https://github.com/{{ page.repository }}">{{ page.repository }}</a>
         </p>
-        <h4 class="mb-1 alt-h4 text-gray">Author</h4>
-        <p>
-          <a class="text-inherit" href="https://github.com/{{ page.author }}">{{ page.author }}</a>
-        </p>
+        <h4 class="mb-1 alt-h4 text-gray">Authors</h4>
+        {% for author in page.authors %}
+          <p>
+            <a class="text-inherit" href="https://github.com/{{ author }}">{{ author }}</a>
+          </p>
+        {% endfor %}
         <h4 class="mb-1 alt-h4 text-gray">Updated</h4>
         <p><span class="text-white">{{ page.updated | date: "%B %e, %Y"}}</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,9 @@ layout: default
               <div class="d-flex flex-row">
                 <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ app.stars }}</span></div>
                 <div class="col-9 text-right">
-                  <img class="avatar tooltipped tooltipped-s" alt="Made by {{ app.author }}" aria-label="Made by {{ app.author }}" height="24" src="https://github.com/{{ app.author }}.png">
+                  {% for author in app.authors %}
+                    <img class="avatar tooltipped tooltipped-s" alt="Made by {{ author }}" aria-label="Made by {{ author }}" height="24" src="https://github.com/{{ author }}.png">
+                  {% endfor %}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Changes `author` => `authors` and makes the data expect an array so that projects with multiple authors can properly attribute that. Below are screenshots of what it looks like now.

<img width="337" alt="screen shot 2017-09-11 at 8 40 48 pm" src="https://user-images.githubusercontent.com/13410355/30291087-f45ab4c2-9731-11e7-9c18-5e8ab3d5d082.png">

<img width="217" alt="screen shot 2017-09-11 at 8 41 17 pm" src="https://user-images.githubusercontent.com/13410355/30291091-f9f6adc8-9731-11e7-8886-67d39eb9f2f9.png">

cc/ @techforchange