### PR TITLE
Set timezone for cal entry

### DIFF
--- a/assets/js/office-hours.js
+++ b/assets/js/office-hours.js
@@ -6,16 +6,16 @@ var debug = false;
 // Adjust to Friday at 17:00 UTC / 1pm Eastern
 var attrs = {day: "Friday", hour: 17, minute: 0, second: 0, millisecond: 0}
 
-var start = moment().utc().set(attrs).local()
+var start = moment().utc().set(attrs)
 
 // If it's already passed today, go to next Friday
 if(start < moment()) {
   start.add({days: 7})
 }
 
-end = moment(start).add({hour: 1})
+var end = moment(start).add({hour: 1})
 
-if(debug || start < moment().add(4, 'hours')) {
+if(debug || start < moment().utc().add(4, 'hours')) {
   document.body.classList.add('office-hours-soon')
   document.querySelectorAll('.office-hours-nag').forEach(function(el) {
     el.classList.remove('d-none')

--- a/contribute.html
+++ b/contribute.html
@@ -44,6 +44,7 @@ office_hours_link: https://github.zoom.us/j/221410810
         <var class="atc_event">
           <var class="atc_date_start js-office-hours-start-time"></var>
           <var class="atc_date_end js-office-hours-end-time"></var>
+          <var class="atc_timezone">UTC</var>
           <var class="atc_title">Probot Office Hours</var>
           <var class="atc_description">Join us every Friday to give feedback, ask questions, get help, or just chat about ideas.</var>
           <var class="atc_location">{{ page.office_hours_link }}</var>


### PR DESCRIPTION
Fixes #61 by setting `atc_timezone`, which is required for the calendar widget.

