### PR TITLE
Use local time for display

### DIFF
--- a/assets/js/office-hours.js
+++ b/assets/js/office-hours.js
@@ -31,9 +31,9 @@ function displayTime(elements, time) {
     var value;
 
     if(format == 'fromNow') {
-      value = time.fromNow();
+      value = time.local().fromNow();
     } else {
-      value = time.format(format);
+      value = time.local().format(format);
     }
 
     el.innerHTML = value;


### PR DESCRIPTION
#62 switched to use UTC internally, which means the time displayed on the website is now in UTC. This updates it to display the time in the local tz.

## Before

<img width="563" alt="contribute___probot" src="https://user-images.githubusercontent.com/173/31018609-60343a6a-a4f2-11e7-9193-b9d6c3c294df.png">

## After

<img width="553" alt="contribute___probot" src="https://user-images.githubusercontent.com/173/31018686-91d123a8-a4f2-11e7-8273-66195fa31646.png">
