### PR TITLE
#63 Fixes nav mobile layout

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
 
 <div class="{% unless homepage %}border-bottom{% endunless %}">
   <div class="container-lg px-3">
-    <div class="py-4 d-flex flex-row flex-justify-between">
+    <div class="py-4 d-flex flex-justify-between">
       <h1 class="alt-h4 lh-default v-align-middle">
         {% unless homepage %}
         <a href="/" class="no-underline text-uppercase text-brand-blue-dark">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,16 +2,16 @@
 
 <div class="{% unless homepage %}border-bottom{% endunless %}">
   <div class="container-lg px-3">
-    <div class="py-4 d-sm-flex flex-sm-row">
-      <h1 class="alt-h4 col-sm-4 lh-default v-align-middle">
+    <div class="py-4 d-flex flex-row flex-justify-between">
+      <h1 class="alt-h4 lh-default v-align-middle">
         {% unless homepage %}
         <a href="/" class="no-underline text-uppercase text-brand-blue-dark">
           <img class="v-align-middle" style="margin: -12px 8px -12px 0;" src="/assets/probot-head.png" height="36" alt="">
-          Probot
+          <span class="d-xs-none">Probot</span>
         </a>
         {% endunless %}
       </h1>
-      <nav class="text-bold col-sm-8 text-sm-right">
+      <nav class="text-bold text-right">
         <a class="text-inherit px-2 d-inline-block" href="/apps/">Explore</a>
         <a class="text-inherit px-2 d-inline-block" href="/docs/">Build</a>
         <a class="text-inherit px-2 d-inline-block" href="/contribute/">Contribute</a>

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -27,3 +27,9 @@ img {
 code {
   font-size: 14px;
 }
+
+@media (max-width: 543px) {
+	.d-xs-none {
+		display: none!important;
+	}
+}

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -29,7 +29,7 @@ code {
 }
 
 @media (max-width: 543px) {
-	.d-xs-none {
-		display: none!important;
-	}
+  .d-xs-none {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
- Simplified a few classes like 'flex-sm-row' to 'flex-row'
[The -sm columns don't work below 544px hence was causing the break in the layout]
- Added the class 'flex-justify-between' to align the nav instead of using 'col-*'
[Simpler way to put the nav on either end]
- Put 'Probot' inside a span that is visible only on width >544px
[Added a custom class 'd-xs-none' that can be used with other elements as well in future]