### PR TITLE
Use hide-sm instead of custom d-xs-none

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,7 +7,7 @@
         {% unless homepage %}
         <a href="/" class="no-underline text-uppercase text-brand-blue-dark">
           <img class="v-align-middle" style="margin: -12px 8px -12px 0;" src="/assets/probot-head.png" height="36" alt="">
-          <span class="d-xs-none">Probot</span>
+          <span class="hide-sm">Probot</span>
         </a>
         {% endunless %}
       </h1>

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -27,9 +27,3 @@ img {
 code {
   font-size: 14px;
 }
-
-@media (max-width: 543px) {
-  .d-xs-none {
-    display: none !important;
-  }
-}


### PR DESCRIPTION
Update to https://github.com/probot/probot.github.io/pull/69 to use the existing `hide-sm` class instead of adding a new custom class.

cc @batraman @JasonEtco 