### PR TITLE
Fix auth for sync script

### DIFF
--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -4,11 +4,11 @@ description: Enforce the DCO on Pull Requests
 slug: dco
 screenshots:
 - https://cloud.githubusercontent.com/assets/173/24482273/a35dc23e-14b5-11e7-9371-fd241873e2c3.png
-stars: 26
+stars: 27
 authors:
 - bkeepers
 repository: probot/dco
-updated: 2017-09-29 05:46:26 UTC
+updated: 2017-10-03 12:04:54 UTC
 ---
 
 

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -7,9 +7,9 @@ screenshots:
 authors:
 - agonzalez0515
 - Techforchange
-stars: 26
+stars: 27
 repository: hoodiehq/first-timers-bot
-updated: 2017-09-30 05:57:19 UTC
+updated: 2017-10-04 15:23:14 UTC
 ---
 
 # first-timers-bot

--- a/_apps/gpg.md
+++ b/_apps/gpg.md
@@ -9,7 +9,7 @@ authors:
 - jarrodldavis
 repository: jarrodldavis/probot-gpg
 stars: 6
-updated: 2017-10-01 03:27:21 UTC
+updated: 2017-10-04 10:13:41 UTC
 ---
 ## Usage
 

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -2,13 +2,13 @@
 title: Settings
 description: Pull Requests for repository settings
 slug: settings
-stars: 141
+stars: 144
 authors:
 - bkeepers
 repository: probot/settings
 screenshots:
 - https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png
-updated: 2017-09-27 23:32:56 UTC
+updated: 2017-10-03 21:24:48 UTC
 ---
 
 This GitHub App syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.

--- a/_apps/todo.md
+++ b/_apps/todo.md
@@ -4,8 +4,11 @@ description: Creates new issues from actionable comments in your code.
 slug: todo
 screenshots:
 - https://user-images.githubusercontent.com/10660468/31048765-83569c30-a5f2-11e7-933a-a119d43ad029.png
-authors: [JasonEtco]
+authors:
+- JasonEtco
 repository: JasonEtco/todo
+stars: 6
+updated: 2017-10-04 23:31:21 UTC
 ---
 ## Usage
 

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -6,7 +6,7 @@ screenshots:
 - https://user-images.githubusercontent.com/13410355/28288851-679f582a-6af5-11e7-8dd8-b85b6c33e16b.png
 - https://user-images.githubusercontent.com/13410355/28288547-5f83aa8e-6af4-11e7-9692-eb41d42431e2.png
 - https://user-images.githubusercontent.com/13410355/28289605-1ab81a76-6af8-11e7-8f78-6a1b3948df36.png
-stars: 16
+stars: 17
 authors:
 - hiimbex
 repository: behaviorbot/welcome

--- a/_apps/wip.md
+++ b/_apps/wip.md
@@ -7,7 +7,7 @@ screenshots:
 authors:
 - gr2m
 repository: gr2m/wip-bot
-stars: 10
+stars: 14
 updated: 2017-09-17 00:18:55 UTC
 ---
 

--- a/script/sync-data
+++ b/script/sync-data
@@ -5,7 +5,7 @@ require "bundler/setup"
 require "open-uri"
 require "octokit"
 require "yaml"
-client = Octokit::Client.new(:access_token => ENV["GITHUB_TOKEN"])
+client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"])
 
 files = ARGV[0] ? [ARGV[0]] : Dir.glob('_apps/*.md')
 


### PR DESCRIPTION
It looks like I broke this in https://github.com/probot/probot.github.io/commit/885ece0ffc331810cbf9ddc54339dfdc05b172cc by renaming the `GH_TOKEN` variable to `GITHUB_TOKEN`.

Fixes #70 