### PR TITLE
Add link to The Changelog episode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read) rescue ">0"
 
 group :jekyll_plugins do
+  gem 'jekyll-redirect-from'
   gem 'github-pages', versions['github-pages']
   gem 'jekyll-octicons'
   gem 'jekyll-livereload'
@@ -21,3 +22,5 @@ group :test do
 end
 
 gem 'rb-fsevent', '0.9.8' # See issue https://github.com/guard/listen/issues/431
+
+# Added at 2017-10-23 15:14:34 -0400 by jasonetcovitch:

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ defaults:
       layout: docs
 
 plugins:
+  - jekyll-redirect-from
   - jekyll-octicons
   - jekyll-sitemap
   - jekyll-seo-tag

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -14,7 +14,7 @@
       <nav class="text-bold text-right">
         <a class="text-inherit px-2 d-inline-block" href="/apps/">Apps</a>
         <a class="text-inherit px-2 d-inline-block" href="/docs/">Docs</a>
-        <a class="text-inherit px-2 d-inline-block" href="/contribute/">Community</a>
+        <a class="text-inherit px-2 d-inline-block" href="/community/">Community</a>
       </nav>
     </div>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
     <script defer src="/assets/js/office-hours.js" charset="utf-8"></script>
   </head>
   <body>
-    <a class="alt-text text-white d-block bg-brand-blue text-center text-white p-3 office-hours-nag d-none" href="/contribute/#office-hours">
+    <a class="alt-text text-white d-block bg-brand-blue text-center text-white p-3 office-hours-nag d-none" href="/community/#office-hours">
       Join us for office hours
       <span class="js-office-hours-start-time" data-format="fromNow"></span>!
     </a>

--- a/community.html
+++ b/community.html
@@ -61,6 +61,23 @@ office_hours_link: https://github.zoom.us/j/221410810
       </a>
     </div>
   </div>
+
+  <div class="border-top container-md py-4 mx-auto d-block d-md-flex gutter-md">
+    <div class="col-12 col-md-6 mb-4 mb-md-0">
+      <div class="p-0 p-md-4">
+        {% octicon unmute class:"mr-2 text-gray" %}
+        Listen to The Changelog #264: <a class="text-bold" href="https://changelog.com/podcast/264">Automating GitHub with Probot</a>
+      </div>
+    </div>
+    <div class="col-12 col-md-6">
+      <div class="p-0 p-md-4">
+        {% octicon device-camera-video class:"mr-2 text-gray" %}
+        Watch the talk at GitHub Universe: <a class="text-bold" href="https://www.facebook.com/GitHub/videos/vb.262588213843476/1194319640670324">Extending with GitHub: easy integrations with Probot</a>
+      </div>
+    </div>
+  </div>
 </div>
+
+
 
 <script async src="//addtocalendar.com/atc/1.5/atc.min.js" charset="utf-8"></script>

--- a/community.html
+++ b/community.html
@@ -2,6 +2,8 @@
 layout: default
 title: Community
 office_hours_link: https://github.zoom.us/j/221410810
+redirect_from:
+  - /contribute/
 ---
 
 <div class="container-lg px-3 featurette">

--- a/community.html
+++ b/community.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Contribute
+title: Community
 office_hours_link: https://github.zoom.us/j/221410810
 ---
 

--- a/index.html
+++ b/index.html
@@ -115,11 +115,3 @@ module.exports = robot => {
     </div>
   </div>
 </div>
-
-
-<div class="border-top py-4">
-  <div class="container-lg px-3 text-center">
-    {% octicon unmute class:"mr-2" %}
-    Listen to The Changelog #264: <a class="text-bold" href="https://changelog.com/podcast/264">Automating GitHub with Probot</a>
-  </div>
-</div>

--- a/index.html
+++ b/index.html
@@ -115,3 +115,11 @@ module.exports = robot => {
     </div>
   </div>
 </div>
+
+
+<div class="border-top py-4">
+  <div class="container-lg px-3 text-center">
+    {% octicon unmute class:"mr-2" %}
+    Listen to The Changelog #264: <a class="text-bold" href="https://changelog.com/podcast/264">Automating GitHub with Probot</a>
+  </div>
+</div>


### PR DESCRIPTION
I wanted to link up the changelog episode that we did a few weeks ago. There's not really a logical place to put it on the website right now, so I just added it on the homepage right above the footer. I'm open to other ideas.

I also tried using the embeddable player from changelog, but I couldn't really figure out how to make it fit and look good.

@JasonEtco would you be interested in fiddling with this to see what feels best to you?

![](https://user-images.githubusercontent.com/173/31773457-738032f2-b4a8-11e7-8dee-485da2a033d4.png)
