### PR TITLE
Installations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ screenshots:
 authors: [ your-username, other-usernames ]
 # The repository where the code is located
 repository: your-username/your-app
+# The address where this app is deployed
+host: https://my-probot-app.awesomecloudhost.com
 ---
 
 Any documentation can go here. Many apps just use their README.md here.

--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -4,13 +4,13 @@ description: Enforce the DCO on Pull Requests
 slug: dco
 screenshots:
 - https://cloud.githubusercontent.com/assets/173/24482273/a35dc23e-14b5-11e7-9371-fd241873e2c3.png
-stars: 27
+stars: 28
 authors:
 - bkeepers
 repository: probot/dco
-updated: 2017-10-19 11:48:05 UTC
+updated: 2017-10-19 15:02:50 UTC
 host: https://probot-dco.herokuapp.com
-installations: 62
+installations: 64
 organizations:
 - hyperledger
 - jaegertracing

--- a/_apps/dco.md
+++ b/_apps/dco.md
@@ -9,6 +9,19 @@ authors:
 - bkeepers
 repository: probot/dco
 updated: 2017-10-19 11:48:05 UTC
+host: https://probot-dco.herokuapp.com
+installations: 62
+organizations:
+- hyperledger
+- jaegertracing
+- envoyproxy
+- phpmyadmin
+- WeblateOrg
+- coreinfrastructure
+- redhat-developer
+- jbosstools
+- mainflux
+- mdeguzis
 ---
 
 

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -11,6 +11,18 @@ stars: 66
 repository: hoodiehq/first-timers-bot
 updated: 2017-10-19 07:58:48 UTC
 host: https://first-timers-bot.now.sh
+installations: 71
+organizations:
+- jekyll
+- processing
+- hoodiehq
+- skywinder
+- sotayamashita
+- cpmech
+- jeremykenedy
+- jywarren
+- publiclab
+- codefordenver
 ---
 
 # first-timers-bot

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -7,22 +7,22 @@ screenshots:
 authors:
 - agonzalez0515
 - Techforchange
-stars: 67
+stars: 72
 repository: hoodiehq/first-timers-bot
-updated: 2017-10-20 04:52:57 UTC
+updated: 2017-10-22 17:56:49 UTC
 host: https://first-timers-bot.now.sh
-installations: 71
+installations: 99
 organizations:
 - jekyll
 - processing
+- Moya
 - hoodiehq
 - skywinder
+- mikaelbr
+- gr2m
 - sotayamashita
 - cpmech
 - jeremykenedy
-- jywarren
-- publiclab
-- codefordenver
 ---
 
 # first-timers-bot

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -10,7 +10,7 @@ authors:
 stars: 66
 repository: hoodiehq/first-timers-bot
 updated: 2017-10-19 07:58:48 UTC
-host: https://first-timers-bot.glitch.me
+host: https://first-timers-bot.now.sh
 ---
 
 # first-timers-bot

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -7,9 +7,9 @@ screenshots:
 authors:
 - agonzalez0515
 - Techforchange
-stars: 66
+stars: 67
 repository: hoodiehq/first-timers-bot
-updated: 2017-10-19 07:58:48 UTC
+updated: 2017-10-20 04:52:57 UTC
 host: https://first-timers-bot.now.sh
 installations: 71
 organizations:

--- a/_apps/first-timers.md
+++ b/_apps/first-timers.md
@@ -10,6 +10,7 @@ authors:
 stars: 66
 repository: hoodiehq/first-timers-bot
 updated: 2017-10-19 07:58:48 UTC
+host: https://first-timers-bot.glitch.me
 ---
 
 # first-timers-bot

--- a/_apps/gpg.md
+++ b/_apps/gpg.md
@@ -9,7 +9,7 @@ authors:
 - jarrodldavis
 repository: jarrodldavis/probot-gpg
 stars: 14
-updated: 2017-10-17 14:06:23 UTC
+updated: 2017-10-22 00:03:52 UTC
 ---
 ## Usage
 

--- a/_apps/invite-contributors.md
+++ b/_apps/invite-contributors.md
@@ -7,8 +7,14 @@ screenshots:
 authors:
 - erickzhao
 repository: erickzhao/invite-contributors
-stars: 2
-updated: 2017-10-19 12:18:07 UTC
+stars: 5
+updated: 2017-10-19 15:53:25 UTC
+host: https://vast-stream-78160.herokuapp.com
+installations: 4
+organizations:
+- flyve-mdm
+- aethonanbot
+- elodiebot
 ---
 
 # invite-contributors

--- a/_apps/invite-contributors.md
+++ b/_apps/invite-contributors.md
@@ -7,7 +7,7 @@ screenshots:
 authors:
 - erickzhao
 repository: erickzhao/invite-contributors
-stars: 0
+stars: 2
 updated: 2017-10-19 12:18:07 UTC
 ---
 

--- a/_apps/invite-contributors.md
+++ b/_apps/invite-contributors.md
@@ -8,13 +8,14 @@ authors:
 - erickzhao
 repository: erickzhao/invite-contributors
 stars: 5
-updated: 2017-10-19 15:53:25 UTC
+updated: 2017-10-21 22:18:19 UTC
 host: https://vast-stream-78160.herokuapp.com
 installations: 4
 organizations:
 - flyve-mdm
 - aethonanbot
 - elodiebot
+- dddpppmmm
 ---
 
 # invite-contributors

--- a/_apps/reminders.md
+++ b/_apps/reminders.md
@@ -9,7 +9,20 @@ authors:
 - bkeepers
 repository: probot/reminders
 stars: 5
-updated: 2017-10-15 11:44:42 UTC
+updated: 2017-10-19 14:18:48 UTC
+host: https://probot-reminders.herokuapp.com
+installations: 31
+organizations:
+- chaijs
+- devtools-html
+- thibmaek
+- carambalabs
+- gillesdemey
+- probot
+- coredns
+- tunnckoCore-old
+- andycasey
+- joshuar
 ---
 
 Use the `/remind` slash command to set a reminder on any comment box on GitHub and you'll get a ping about it again when the reminder is due.

--- a/_apps/reminders.md
+++ b/_apps/reminders.md
@@ -11,7 +11,7 @@ repository: probot/reminders
 stars: 5
 updated: 2017-10-19 14:18:48 UTC
 host: https://probot-reminders.herokuapp.com
-installations: 31
+installations: 30
 organizations:
 - chaijs
 - devtools-html
@@ -20,9 +20,9 @@ organizations:
 - gillesdemey
 - probot
 - coredns
-- tunnckoCore-old
 - andycasey
 - joshuar
+- behaviorbot
 ---
 
 Use the `/remind` slash command to set a reminder on any comment box on GitHub and you'll get a ping about it again when the reminder is due.

--- a/_apps/reminders.md
+++ b/_apps/reminders.md
@@ -8,7 +8,7 @@ authors:
 - jbjonesjr
 - bkeepers
 repository: probot/reminders
-stars: 5
+stars: 6
 updated: 2017-10-19 14:18:48 UTC
 host: https://probot-reminders.herokuapp.com
 installations: 30

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -9,7 +9,7 @@ stars: 8
 authors:
 - hiimbex
 repository: behaviorbot/request-info
-updated: 2017-10-20 03:21:57 UTC
+updated: 2017-10-21 13:29:36 UTC
 host: https://probot-request-info.herokuapp.com
 installations: 27
 organizations:

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -5,13 +5,13 @@ description: Requests more info on issues and pull requests with the default tit
 slug: request-info
 screenshots:
 - https://user-images.githubusercontent.com/13410355/28132821-d37bf2a8-66f2-11e7-9e7b-5930ba65d67a.png
-stars: 7
+stars: 8
 authors:
 - hiimbex
 repository: behaviorbot/request-info
-updated: 2017-10-17 21:59:03 UTC
+updated: 2017-10-20 03:21:57 UTC
 host: https://probot-request-info.herokuapp.com
-installations: 26
+installations: 27
 organizations:
 - desktop
 - benbalter

--- a/_apps/request-info.md
+++ b/_apps/request-info.md
@@ -10,6 +10,19 @@ authors:
 - hiimbex
 repository: behaviorbot/request-info
 updated: 2017-10-17 21:59:03 UTC
+host: https://probot-request-info.herokuapp.com
+installations: 26
+organizations:
+- desktop
+- benbalter
+- terkelg
+- probot
+- Mte90
+- WPBP
+- behaviorbot
+- chriscantu
+- CodeAtCode
+- vuematerial
 ---
 
 

--- a/_apps/sentiment-bot.md
+++ b/_apps/sentiment-bot.md
@@ -10,6 +10,7 @@ authors:
 - hiimbex
 repository: behaviorbot/sentiment-bot
 updated: 2017-10-10 14:39:23 UTC
+host: https://probot-sentiment-bot.herokuapp.com
 ---
 
 Replies to toxic comments with a maintainer designated reply and a link to the repo's code of conduct. It does so by taking data from a `.github/config.yml`.

--- a/_apps/sentiment-bot.md
+++ b/_apps/sentiment-bot.md
@@ -9,8 +9,18 @@ stars: 12
 authors:
 - hiimbex
 repository: behaviorbot/sentiment-bot
-updated: 2017-10-10 14:39:23 UTC
+updated: 2017-10-19 15:54:50 UTC
 host: https://probot-sentiment-bot.herokuapp.com
+installations: 17
+organizations:
+- MvvmCross
+- carambalabs
+- probot
+- xcodeswift
+- vuematerial
+- WormieCorp
+- marclop
+- AdmiringWorm
 ---
 
 Replies to toxic comments with a maintainer designated reply and a link to the repo's code of conduct. It does so by taking data from a `.github/config.yml`.

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -8,9 +8,9 @@ authors:
 repository: probot/settings
 screenshots:
 - https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png
-updated: 2017-10-17 14:05:49 UTC
+updated: 2017-10-19 15:02:31 UTC
 host: https://github-configurer.herokuapp.com
-installations: 50
+installations: 51
 organizations:
 - apollographql
 - denysdovhan

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -9,6 +9,19 @@ repository: probot/settings
 screenshots:
 - https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png
 updated: 2017-10-17 14:05:49 UTC
+host: https://github-configurer.herokuapp.com
+installations: 50
+organizations:
+- apollographql
+- denysdovhan
+- benbalter
+- probot
+- coveralls-clients
+- LambdaBooks
+- whizark
+- flyve-mdm
+- ignatandrei
+- prasanthj
 ---
 
 This GitHub App syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.

--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -2,7 +2,7 @@
 title: Settings
 description: Pull Requests for repository settings
 slug: settings
-stars: 153
+stars: 154
 authors:
 - bkeepers
 repository: probot/settings
@@ -10,7 +10,7 @@ screenshots:
 - https://user-images.githubusercontent.com/173/29472917-3fad9db0-841b-11e7-8f6d-a6c63052122b.png
 updated: 2017-10-19 15:02:31 UTC
 host: https://github-configurer.herokuapp.com
-installations: 51
+installations: 52
 organizations:
 - apollographql
 - denysdovhan

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -10,6 +10,19 @@ authors:
 stars: 183
 repository: probot/stale
 updated: 2017-10-15 11:46:44 UTC
+host: https://probot-stale.herokuapp.com
+installations: 224
+organizations:
+- atom
+- facebook
+- Homebrew
+- nwjs
+- fchollet
+- apollographql
+- hexojs
+- strongloop
+- sequelize
+- kivy
 ---
 
 Automatically close stale Issues and Pull Requests that tend to accumulate during a project.

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -7,11 +7,11 @@ screenshots:
 - https://user-images.githubusercontent.com/173/27765705-93f94940-5e7e-11e7-8527-3a91bb64ca70.png
 authors:
 - bkeepers
-stars: 183
+stars: 185
 repository: probot/stale
-updated: 2017-10-15 11:46:44 UTC
+updated: 2017-10-19 14:42:26 UTC
 host: https://probot-stale.herokuapp.com
-installations: 224
+installations: 228
 organizations:
 - atom
 - facebook

--- a/_apps/stale.md
+++ b/_apps/stale.md
@@ -7,11 +7,11 @@ screenshots:
 - https://user-images.githubusercontent.com/173/27765705-93f94940-5e7e-11e7-8527-3a91bb64ca70.png
 authors:
 - bkeepers
-stars: 185
+stars: 186
 repository: probot/stale
-updated: 2017-10-19 14:42:26 UTC
+updated: 2017-10-22 19:01:14 UTC
 host: https://probot-stale.herokuapp.com
-installations: 228
+installations: 231
 organizations:
 - atom
 - facebook
@@ -22,7 +22,7 @@ organizations:
 - hexojs
 - strongloop
 - sequelize
-- kivy
+- gatsbyjs
 ---
 
 Automatically close stale Issues and Pull Requests that tend to accumulate during a project.

--- a/_apps/todo.md
+++ b/_apps/todo.md
@@ -7,6 +7,7 @@ screenshots:
 authors:
 - JasonEtco
 repository: JasonEtco/todo
+host: https://todo-api.jasonet.co
 stars: 32
 updated: 2017-10-16 17:55:26 UTC
 ---

--- a/_apps/todo.md
+++ b/_apps/todo.md
@@ -9,7 +9,19 @@ authors:
 repository: JasonEtco/todo
 host: https://todo-api.jasonet.co
 stars: 32
-updated: 2017-10-16 17:55:26 UTC
+updated: 2017-10-19 14:48:46 UTC
+installations: 29
+organizations:
+- thibmaek
+- material-motion
+- phatblat
+- JasonEtco
+- miklb
+- mattstratton
+- jonasbn
+- nikolay
+- KnisterPeter
+- nilbot
 ---
 ## Usage
 

--- a/_apps/todo.md
+++ b/_apps/todo.md
@@ -9,8 +9,8 @@ authors:
 repository: JasonEtco/todo
 host: https://todo-api.jasonet.co
 stars: 32
-updated: 2017-10-19 14:48:46 UTC
-installations: 29
+updated: 2017-10-22 19:29:35 UTC
+installations: 31
 organizations:
 - thibmaek
 - material-motion

--- a/_apps/update-docs.md
+++ b/_apps/update-docs.md
@@ -9,8 +9,15 @@ stars: 5
 authors:
 - hiimbex
 repository: behaviorbot/update-docs
-updated: 2017-10-01 12:48:25 UTC
+updated: 2017-10-19 16:03:37 UTC
 host: https://probot-update-docs.herokuapp.com
+installations: 8
+organizations:
+- adonisjs
+- xcodeswift
+- behaviorbot
+- marclop
+- robotland
 ---
 
 

--- a/_apps/update-docs.md
+++ b/_apps/update-docs.md
@@ -10,6 +10,7 @@ authors:
 - hiimbex
 repository: behaviorbot/update-docs
 updated: 2017-10-01 12:48:25 UTC
+host: https://probot-update-docs.herokuapp.com
 ---
 
 

--- a/_apps/validate-commit-msg-bot.md
+++ b/_apps/validate-commit-msg-bot.md
@@ -9,7 +9,8 @@ authors:
 - tlvince
 repository: tlvince/validate-commit-msg-bot
 stars: 3
-updated: 2017-08-23 08:22:00 UTC
+updated: 2017-10-19 17:04:07 UTC
+host: https://validate-commit-msg-bot.now.sh
 ---
 
 > validate-commit-msg aaS

--- a/_apps/validate-commit-msg-bot.md
+++ b/_apps/validate-commit-msg-bot.md
@@ -11,6 +11,13 @@ repository: tlvince/validate-commit-msg-bot
 stars: 3
 updated: 2017-10-19 17:04:07 UTC
 host: https://validate-commit-msg-bot.now.sh
+installations: 8
+organizations:
+- angular-pouchdb
+- christophehurpeau
+- tlvince
+- nikolay
+- Robophil
 ---
 
 > validate-commit-msg aaS

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -11,6 +11,7 @@ authors:
 - hiimbex
 repository: behaviorbot/welcome
 updated: 2017-09-15 14:50:57 UTC
+host: https://probot-welcome.herokuapp.com
 ---
 
 

--- a/_apps/welcome.md
+++ b/_apps/welcome.md
@@ -10,8 +10,20 @@ stars: 17
 authors:
 - hiimbex
 repository: behaviorbot/welcome
-updated: 2017-09-15 14:50:57 UTC
+updated: 2017-10-19 16:21:15 UTC
 host: https://probot-welcome.herokuapp.com
+installations: 43
+organizations:
+- electron
+- kivy
+- StevenBlack
+- MarshallOfSound
+- benbalter
+- carambalabs
+- karthik
+- probot
+- electron-userland
+- publiclab
 ---
 
 

--- a/_apps/wip.md
+++ b/_apps/wip.md
@@ -7,8 +7,9 @@ screenshots:
 authors:
 - gr2m
 repository: gr2m/wip-bot
-stars: 21
-updated: 2017-10-17 16:39:07 UTC
+stars: 23
+updated: 2017-10-20 06:11:27 UTC
+host: https://wip-bot.now.sh
 ---
 
 If you don’t want a pull request to be merged accidentally, add the word "wip" or "WIP" to its title and WIP bot will set its status to error. That’s all :)

--- a/_apps/wip.md
+++ b/_apps/wip.md
@@ -8,8 +8,20 @@ authors:
 - gr2m
 repository: gr2m/wip-bot
 stars: 23
-updated: 2017-10-20 06:11:27 UTC
+updated: 2017-10-20 18:53:47 UTC
 host: https://wip-bot.now.sh
+installations: 79
+organizations:
+- dotnet
+- kivy
+- aurelia
+- saltstack
+- Microsoft
+- reactiveui
+- hoodiehq
+- semantic-release
+- devtools-html
+- Humanizr
 ---
 
 If you don’t want a pull request to be merged accidentally, add the word "wip" or "WIP" to its title and WIP bot will set its status to error. That’s all :)

--- a/_includes/app.html
+++ b/_includes/app.html
@@ -4,6 +4,9 @@
     <p class="text-gray lh-condensed px-3 pb-3">{{ app.description }}</p>
     <div class="text-gray-light pl-3 pr-2 py-2 bg-gray-light border-top" style="margin-top: auto;">
       <div class="d-flex flex-row">
+        {% if app.installations %}
+        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.installations }} installations">{% octicon cloud-download heigh:16 class:"v-align-middle" %} <span class="">{{ app.installations }}</span></div>
+        {% endif %}
         <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ app.stars }}</span></div>
         <div class="col-9 text-right">
           {% for author in app.authors %}

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -64,7 +64,7 @@ layout: default
           <h4 class="mb-1 alt-h4 text-gray">Used By</h4>
           {% for org in page.organizations %}
             <a href="https://github.com/{{ org }}" aria-label="{{ org }}" class="tooltipped tooltipped-n avatar-group-item">
-              <img class="avatar" src="https://github.com/{{ org }}.png" alt="{{ org }}" width="35" height="35">
+              <img class="avatar bg-white" src="https://github.com/{{ org }}.png" alt="{{ org }}" width="35" height="35">
             </a>
           {% endfor %}
         {% endif %}

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -59,6 +59,15 @@ layout: default
         {% endfor %}
         <h4 class="mb-1 alt-h4 text-gray">Updated</h4>
         <p><span class="text-white">{{ page.updated | date: "%B %e, %Y"}}</p>
+
+        {% if page.organizations %}
+          <h4 class="mb-1 alt-h4 text-gray">Used By</h4>
+          {% for org in page.organizations %}
+            <a href="https://github.com/{{ org }}" aria-label="{{ org }}" class="tooltipped tooltipped-n avatar-group-item">
+              <img class="avatar" src="https://github.com/{{ org }}.png" alt="{{ org }}" width="35" height="35">
+            </a>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
   </div>
@@ -71,16 +80,6 @@ layout: default
         <div class="markdown-body">
           {{ content }}
         </div>
-      </div>
-      <div class="col-md-3">
-        {% if page.organizations %}
-          <h4 class="mb-1 alt-h4 text-gray">Used By</h4>
-          {% for org in page.organizations %}
-            <a href="https://github.com/{{ org }}" aria-label="{{ org }}" class="tooltipped tooltipped-n avatar-group-item">
-              <img class="avatar" src="https://github.com/{{ org }}.png" alt="{{ org }}" width="35" height="35">
-            </a>
-          {% endfor %}
-        {% endif %}
       </div>
     </div>
   </div>

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -77,7 +77,7 @@ layout: default
           <h4 class="mb-1 alt-h4 text-gray">Used By</h4>
           {% for org in page.organizations %}
             <a href="https://github.com/{{ org }}" aria-label="{{ org }}" class="tooltipped tooltipped-n avatar-group-item">
-              <img class="avatar" src="https://github.com/{{ org }}.png" alt-"{{ org }}" width="35" height="35">
+              <img class="avatar" src="https://github.com/{{ org }}.png" alt="{{ org }}" width="35" height="35">
             </a>
           {% endfor %}
         {% endif %}

--- a/_layouts/app.html
+++ b/_layouts/app.html
@@ -15,6 +15,9 @@ layout: default
           Add to GitHub
         </a>
         <div class="text-gray-light">
+          {% if page.installations %}
+          <div class="mr-2 d-inline tooltipped tooltipped-s" aria-label="{{ page.installations }} installations">{% octicon cloud-download heigh:16 class:"v-align-middle" %} <span class="">{{ page.installations }}</span></div>
+          {% endif %}
           <div class="d-inline tooltipped tooltipped-s" aria-label="{{ page.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ page.stars }}</span></div>
         </div>
       </div>
@@ -68,6 +71,16 @@ layout: default
         <div class="markdown-body">
           {{ content }}
         </div>
+      </div>
+      <div class="col-md-3">
+        {% if page.organizations %}
+          <h4 class="mb-1 alt-h4 text-gray">Used By</h4>
+          {% for org in page.organizations %}
+            <a href="https://github.com/{{ org }}" aria-label="{{ org }}" class="tooltipped tooltipped-n avatar-group-item">
+              <img class="avatar" src="https://github.com/{{ org }}.png" alt-"{{ org }}" width="35" height="35">
+            </a>
+          {% endfor %}
+        {% endif %}
       </div>
     </div>
   </div>

--- a/apps/index.html
+++ b/apps/index.html
@@ -8,7 +8,7 @@ title: Featured Apps
     <h1 class="alt-h2">{{ page.title }}</h1>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = site.apps | sort: 'stars' | reverse %}
+      {% assign apps = site.apps | sort: 'installations' | reverse %}
       {% for app in apps %}
         {% include app.html app=app %}
       {% endfor %}

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@ layout: default
     </p>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = site.apps | sort: 'stars' | reverse %}
+      {% assign apps = site.apps | sort: 'installations' | reverse %}
       {% for app in apps limit:6 %}
         {% include app.html app=app %}
       {% endfor %}

--- a/script/sync-data
+++ b/script/sync-data
@@ -18,9 +18,13 @@ files.each do |path|
   app['updated'] = repo[:pushed_at].to_s
 
   if app['host']
-    stats = JSON.parse(URI(app['host'] + '/stats').open.read)
-    app['installations'] = stats['installations']
-    app['organizations'] = stats['popular'].map { |org| org['login'] }
+    begin
+      stats = JSON.parse(URI(app['host'] + '/probot/stats').open.read)
+      app['installations'] = stats['installations']
+      app['organizations'] = stats['popular'].map { |org| org['login'] }
+    rescue => e
+      warn e.message
+    end
   end
 
   content = File.read(path)


### PR DESCRIPTION
Now that https://github.com/probot/probot/pull/181 landed in probot, this updates the website to sync the public stats and show number of installations and popular organizations.

<img width="1052" alt="probot___github_apps_to_automate_and_improve_your_workflow" src="https://user-images.githubusercontent.com/173/31776867-4f93ba8a-b4b2-11e7-8a82-f9d225007b25.png">

---

<img width="1102" alt="stale___probot" src="https://user-images.githubusercontent.com/173/31776921-70116352-b4b2-11e7-8fca-2d9ffe2166bc.png">

---

Before this can get merged, I need to know the URL that the following apps are deployed to so we can fetch the `/probot/stats`. If you're tagged here, can you just comment with the URL for your app? (You'll need to make sure you're running on the latest probot, which you can test by fetching the [`/probot/stats`](http://probot-stale.herokuapp.com/probot/stats) endpoint)

- [ ] gpg (@jarrodldavis)
- [x] invite-contributors (@erickzhao)
- [x] todo (@JasonEtco)
- [x] validate-commit-msg-bot (@tlvince)
- [x] wip (@gr2m)

Also, the following apps need to update to the latest probot with `npm install probot@latest`:

- [x] first-timers (@agonzalez0515, @Techforchange)
- [x] sentiment-bot (@hiimbex)
- [x] update-docs (@hiimbex)
- [x] welcome (@hiimbex)
- [x] wip (@gr2m)

