### PR TITLE
Vertically center installation/star numbers

### DIFF
--- a/_includes/app.html
+++ b/_includes/app.html
@@ -5,9 +5,9 @@
     <div class="text-gray-light pl-3 pr-2 py-2 bg-gray-light border-top" style="margin-top: auto;">
       <div class="d-flex flex-row">
         {% if app.installations %}
-        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.installations }} installations">{% octicon cloud-download heigh:16 class:"v-align-middle" %} <span class="">{{ app.installations }}</span></div>
+        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.installations }} installations">{% octicon cloud-download heigh:16 class:"v-align-middle" %} <span class="v-align-middle">{{ app.installations }}</span></div>
         {% endif %}
-        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="">{{ app.stars }}</span></div>
+        <div class="col-3 tooltipped tooltipped-s" aria-label="{{ app.stars }} stars">{% octicon star heigh:16 class:"v-align-middle" %} <span class="v-align-middle">{{ app.stars }}</span></div>
         <div class="col-9 text-right">
           {% for author in app.authors %}
             <img class="avatar tooltipped tooltipped-s" alt="Made by {{ author }}" aria-label="Made by {{ author }}" height="24" src="https://github.com/{{ author }}.png">


### PR DESCRIPTION
The numbers for the installation and stars stats are just a liiiiitle off vertical center compared to the icons. It's a really minor difference but it was bugging me 😊 

Before:
![image](https://user-images.githubusercontent.com/10660468/31907716-9f3e6762-b802-11e7-9019-f29bfd102b6a.png)

After: 
![image](https://user-images.githubusercontent.com/10660468/31907703-94ff2ce6-b802-11e7-9f4c-324723d66dbf.png)
