### PR TITLE
Make the table of contents in the docs stay visible

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -38,34 +38,36 @@ layout: default
       </p>
     </div>
     <div id="toc" class="col-md-3 py-6">
-      {% for section in site.data.toc %}
-        <h2 class="alt-h4">{{ section[0] }}</h2>
+      <div class="toc-wrap">
+        {% for section in site.data.toc %}
+          <h2 class="alt-h4">{{ section[0] }}</h2>
 
-        <ul class="mt-2 mb-4 list-style-none">
-          {% for item in section[1] %}
-            <li>
-              {% if item.url %}
-                {% assign link = item %}
-              {% else %}
-                {% for doc in site.pages %}
-                  {% if doc.path == item %}
-                    {% assign link = doc %}
-                    {% break %}
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
+          <ul class="mt-2 mb-4 list-style-none">
+            {% for item in section[1] %}
+              <li>
+                {% if item.url %}
+                  {% assign link = item %}
+                {% else %}
+                  {% for doc in site.pages %}
+                    {% if doc.path == item %}
+                      {% assign link = doc %}
+                      {% break %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
 
-              {% if page.url == link.url %}
-                {% assign classes = "text-brand-red" %}
-              {% else %}
-                {% assign classes = "text-gray-light" %}
-              {% endif %}
+                {% if page.url == link.url %}
+                  {% assign classes = "text-brand-red" %}
+                {% else %}
+                  {% assign classes = "text-gray-light" %}
+                {% endif %}
 
-              <a class="d-block no-underline py-1 {{classes}}" href="{{ link.url }}">{{ link.title }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-      {% endfor %}
+                <a class="d-block no-underline py-1 {{classes}}" href="{{ link.url }}">{{ link.title }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endfor %}
+      </div>
     </div>
   </div>
 </div>

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -27,3 +27,22 @@ img {
 code {
   font-size: 14px;
 }
+
+/*
+ * Extend the footer to the bottom of the page,
+ * even if there’s not enough content to make the page scroll.
+ */
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.container-lg {
+  flex: 1;
+}
+
+#toc .toc-wrap {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 40px;
+}


### PR DESCRIPTION
This adds `position: sticky` to the sidebar, making it stay in place. I tried adding the styles to the `#toc` div, but since it expands to match the height of the content, I had to wrap the table of contents in its own `<div>`.

<img width="442" alt="screen shot 2017-10-27 at 15 36 43" src="https://user-images.githubusercontent.com/25517624/32121976-cba2acdc-bb2c-11e7-8da3-588f2c1a0fd9.png">
