### PR TITLE
Add include that will return 4 random example apps

### DIFF
--- a/_includes/docs/examples.html
+++ b/_includes/docs/examples.html
@@ -1,0 +1,7 @@
+{% assign apps = site.apps | sample:4 %}
+
+<ul>
+{% for app in apps %}
+  <li><a href="{{ app.url }}">{{ app.title }}</a> - {{ app.description }}</li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
As more and more cool apps are built, it'd be nice to show them off as examples of things that can be built with Probot on https://probot.github.io/docs/. 

This PR adds a template that returns 4 random apps, which can be included on the docs site. Every time the site is rebuilt (every merged PR, and every day when the stats are synced), the list of example apps will update.

---
<img width="756" alt="introduction___probot" src="https://user-images.githubusercontent.com/173/32702073-9a8bef56-c7a6-11e7-9ed3-4e0328b8f576.png">
