### PR TITLE
Link to octokit in reference docs

### DIFF
--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -15,9 +15,9 @@ Advanced:
   - docs/persistence.md
   - docs/best-practices.md
 Reference:
-  - title: GitHub API
-    url: "http://octokit.github.io/rest.js/"
   - title: robot
     url: "https://probot.github.io/api/latest/Robot.html"
   - title: context
     url: "https://probot.github.io/api/latest/Context.html"
+  - title: context.github
+    url: "http://octokit.github.io/rest.js/"

--- a/_data/toc.yml
+++ b/_data/toc.yml
@@ -15,6 +15,8 @@ Advanced:
   - docs/persistence.md
   - docs/best-practices.md
 Reference:
+  - title: GitHub API
+    url: "http://octokit.github.io/rest.js/"
   - title: robot
     url: "https://probot.github.io/api/latest/Robot.html"
   - title: context


### PR DESCRIPTION
Making GitHub API calls is one of the more common things reference docs are needed for. This adds a link in the docs sidebar to the octokit API docs.