### PR TITLE
Add Stack Overflow button

### DIFF
--- a/community.html
+++ b/community.html
@@ -21,8 +21,12 @@ redirect_from:
       Contribute on GitHub
     </a>
 
-    <a class="btn btn-outline d-inline-block mb-1 mb-md-0" href="https://twitter.com/ProbotTheRobot">
+    <a class="btn btn-outline d-inline-block mb-1 mb-md-0 mr-0 mr-md-3" href="https://twitter.com/ProbotTheRobot">
       Follow on Twitter
+    </a>
+
+    <a class="btn btn-outline d-inline-block mb-1" href="https://stackoverflow.com/questions/tagged/probot">
+      Probot on Stack Overflow
     </a>
   </div>
 


### PR DESCRIPTION
Adds a link to our shiny new Stack Overflow tag to the  `/community` page.