### PR TITLE
remove script/bootstrap to avoid double bundle install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-before_script: "./script/bootstrap"
 script: "./script/cibuild"
 language: ruby
 rvm:


### PR DESCRIPTION
Closes #160. The repeat was coming from running `script/bootstrap` as a before script. You can see here: https://travis-ci.org/probot/probot.github.io/jobs/368180779 (test for this commit, failing due to #167 and #168 atm), bundle install only gets run once through travis.

I'm not positive but I think everything else in the bootstrap script is specific to local dev, but if you think this removes something important from the test suite let me know.

cc/ @bkeepers 