### PR TITLE
exclude tags for the side bar items

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -80,4 +80,5 @@ layout: default
   };
 
   anchors.add();
+  anchors.remove('.alt-h4');
 </script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -80,5 +80,5 @@ layout: default
   };
 
   anchors.add();
-  anchors.remove('.alt-h4');
+  anchors.remove('.alt-h4'); 
 </script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -80,5 +80,5 @@ layout: default
   };
 
   anchors.add();
-  anchors.remove('.alt-h4'); 
+  anchors.remove('.alt-h4');
 </script>


### PR DESCRIPTION
Closes https://github.com/probot/probot.github.io/issues/183 but maintains all the in page linking.

If you squint you can see that in this low quality gif:
![gif](https://media.giphy.com/media/BfaqqP68IF5OvuXNZY/giphy.gif)