### PR TITLE
delete spammy user

### DIFF
--- a/_apps/settings.md
+++ b/_apps/settings.md
@@ -13,7 +13,6 @@ host: https://github-configurer.herokuapp.com
 installations: 150
 organizations:
 - apollographql
-- CNXTEoEorg
 - denysdovhan
 - bkeepers
 - chaijs


### PR DESCRIPTION
Tests are still failing even though theoretically, this user should have been blacklisted from being listed here. So I thought I'd try manually removing them. (This test failure has been driving me nuts) If they get added back again in the next data sync, then I'll revisit the original implementation for the `IGNORED_ACCOUNTS` option I created.