### PR TITLE
Close Issue

### DIFF
--- a/_apps/close-issue.md
+++ b/_apps/close-issue.md
@@ -6,25 +6,33 @@ screenshots:
 - https://raw.githubusercontent.com/offu/close-issue-app/master/screenshot.png
 authors: [ helloqiu, whtsky ]
 repository: offu/close-issue-app
-host: https://damp-citadel-91689.herokuapp.com
+host: https://close-issue-app.herokuapp.com
 ---
 [![Build Status](https://travis-ci.org/offu/close-issue-app.svg?branch=master)](https://travis-ci.org/offu/close-issue-app)
 [![codecov](https://codecov.io/gh/offu/close-issue-app/branch/master/graph/badge.svg)](https://codecov.io/gh/offu/close-issue-app)  
 ## What It Does
 The app will check new opened and reopened issues if they include some specific contents. Issues not passed will be commented then closed.
 ## Usage
-1. Create a ```/.github/issue-close-bot.yml``` file in your repo. Here's an example:
+1. Create a `.github/issue-close-app.yml` file in your repo. Here's an example:
 ``` yaml
 # Comment that will be sent if an issue is judged to be closed
-comment: test
-# You can have several configs for different issues.
+comment: "This issue is closed because it does not meet our issue template. Please read it."
 issueConfigs:
+# There can be several configs for different kind of issues.
 - content:
-  - content1
-  - content2
-  - "🐶"
+# Example 1: bug report
+  - "Expected Behavior"
+  - "Current Behavior"
+  - "Steps to Reproduce"
+  - "Detailed Description"
 - content:
-  - "🐱"
+# Example 2: feature request
+  - "Motivation / Use Case"
+  - "Expected Behavior"
+  - "Other Information"
+# The issue is judged to be legal if it includes all keywords from any of these two configs.
+# Or it will be closed by the app.
 ```
+The config file is **required** to run this app. And there is no **default config**. If the app can not find a valid config file, it will ignore requests from the repo.
 2. Install the [close-issue-app](https://github.com/apps/close-issue-app).
 3. Enjoy!

--- a/_apps/close-issue.md
+++ b/_apps/close-issue.md
@@ -1,0 +1,30 @@
+---
+title: Close Issue
+description: Comment on the issues that do not include some contents then close them.
+slug: close-issue-bot
+screenshots:
+- https://raw.githubusercontent.com/offu/close-issue-bot/master/screenshot.png
+authors: [ helloqiu, whtsky ]
+repository: offu/close-issue-bot
+host: https://damp-citadel-91689.herokuapp.com
+---
+[![Build Status](https://travis-ci.org/offu/close-issue-bot.svg?branch=master)](https://travis-ci.org/offu/close-issue-bot)
+[![codecov](https://codecov.io/gh/offu/close-issue-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/offu/close-issue-bot)  
+## What It Does
+The bot will check new opened and reopened issues if they include some specific contents. Issues not passed will be commented then closed.
+## Usage
+1. Create a ```/.github/issue-close-bot.yml``` file in your repo. Here's an example:
+``` yaml
+# Comment that will be sent if an issue is judged to be closed
+comment: test
+# You can have several configs for different issues.
+issueConfigs:
+- content:
+  - content1
+  - content2
+  - "🐶"
+- content:
+  - "🐱"
+```
+2. Install the [close-issue-bot](https://github.com/apps/close-issue-bot).
+3. Enjoy!

--- a/_apps/close-issue.md
+++ b/_apps/close-issue.md
@@ -1,17 +1,17 @@
 ---
 title: Close Issue
 description: Comment on the issues that do not include some contents then close them.
-slug: close-issue-bot
+slug: close-issue-app
 screenshots:
-- https://raw.githubusercontent.com/offu/close-issue-bot/master/screenshot.png
+- https://raw.githubusercontent.com/offu/close-issue-app/master/screenshot.png
 authors: [ helloqiu, whtsky ]
-repository: offu/close-issue-bot
+repository: offu/close-issue-app
 host: https://damp-citadel-91689.herokuapp.com
 ---
-[![Build Status](https://travis-ci.org/offu/close-issue-bot.svg?branch=master)](https://travis-ci.org/offu/close-issue-bot)
-[![codecov](https://codecov.io/gh/offu/close-issue-bot/branch/master/graph/badge.svg)](https://codecov.io/gh/offu/close-issue-bot)  
+[![Build Status](https://travis-ci.org/offu/close-issue-app.svg?branch=master)](https://travis-ci.org/offu/close-issue-app)
+[![codecov](https://codecov.io/gh/offu/close-issue-app/branch/master/graph/badge.svg)](https://codecov.io/gh/offu/close-issue-app)  
 ## What It Does
-The bot will check new opened and reopened issues if they include some specific contents. Issues not passed will be commented then closed.
+The app will check new opened and reopened issues if they include some specific contents. Issues not passed will be commented then closed.
 ## Usage
 1. Create a ```/.github/issue-close-bot.yml``` file in your repo. Here's an example:
 ``` yaml
@@ -26,5 +26,5 @@ issueConfigs:
 - content:
   - "🐱"
 ```
-2. Install the [close-issue-bot](https://github.com/apps/close-issue-bot).
+2. Install the [close-issue-app](https://github.com/apps/close-issue-app).
 3. Enjoy!


### PR DESCRIPTION
Hi there.
I create a bot to help developers to **close issues that do not include some specific contents**, which is useful when **the developers provide issue template but the issue does not refer to it**.
I create the bot because I don't find other bots that have similar functions. Hope this bot can help developers to filter useful issues.