### PR TITLE
Adds missing await

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ module.exports = robot => {
     const params = context.issue({
       body: 'Hello World!'
     });
-    context.github.issues.createComment(params);
+    await context.github.issues.createComment(params);
   });
 };
 {% endhighlight %}


### PR DESCRIPTION
Since `createComment` returns a promise, if we don't await for it in case of error we will get an unhandled promise rejection which is bad because we won't be able to debug it and also because in future versions of Node.js the process will crash.