### PR TITLE
jekyll now includes livereload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :jekyll_plugins do
   gem 'jekyll-redirect-from'
   gem 'github-pages', versions['github-pages']
   gem 'jekyll-octicons'
-  gem 'jekyll-livereload'
   gem 'jekyll-readme-index'
   gem 'jemoji'
 end

--- a/script/server
+++ b/script/server
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-bundle exec jekyll serve -L
+bundle exec jekyll serve --livereload


### PR DESCRIPTION
`script/server` currently fails with the latest release of jekyll because the `jekyll-livereload` plugin clashes with the livereload support that is now built into jekyll.