### PR TITLE
Fix cutoff code on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,11 +74,11 @@ layout: default
 
     <div class="page-section">
       <div class="d-md-flex flex-md-row gutter-md flex-md-items-center">
-        <div class="col-md-6">
+        <div class="col-md-5">
           <h3 class="alt-h3 mb-2">Easily scriptable</h3>
           <p class="">Focus on what you want to build. A simple API—built on the latest ES6 JavaScript features—hides the details you don't care about.</p>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-7">
           <div class="rounded-2 overflow-hidden border" style="margin-left: 60px;">
 {% highlight javascript %}
 module.exports = app => {
@@ -95,7 +95,7 @@ module.exports = app => {
       </div>
 
       <div class="d-md-flex flex-md-row flex-md-row-reverse gutter mt-4">
-        <div class="col-md-6">
+        <div class="col-md-7">
           <img alt="" src="https://github.com/probot.png" height="44" width="44" class="avatar rounded-1 float-left">
           <div class="timeline-comment box rounded-2 border bg-white" style="margin-left: 60px;">
             <div class="bg-gray px-3 py-2 border-bottom">
@@ -104,7 +104,7 @@ module.exports = app => {
             <p class="m-0 p-3">Hello World!</p>
           </div>
         </div>
-        <div class="col-md-6">
+        <div class="col-md-5">
           <h2 class="alt-h3 mb-2"></h2>
           <p>Apps are first class actors within GitHub.</p>
           <p class="mt-3">


### PR DESCRIPTION
Fixes the cutoff code on the homepage by tweakin' some column classes.

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/10660468/42199090-60f1a554-7e5a-11e8-985a-ece0ca3b9583.png">


Closes #200 