### PR TITLE
Advance to next week if start is past

### DIFF
--- a/assets/js/office-hours.js
+++ b/assets/js/office-hours.js
@@ -5,10 +5,14 @@ var debug = false;
 
 // Adjust to Thursday at 17:00 UTC / 1pm EDT
 var attrs = {day: "Thursday", hour: 17, minute: 0, second: 0, millisecond: 0}
-
 var start = moment().utc().set(attrs)
-var end = start.clone().add({hour: 1})
 
+// If it's already passed today, go to the next occurrence
+if(start < moment()) {
+  start.add({days: 7})
+}
+
+var end = start.clone().add({hour: 1})
 
 if(debug || start < moment().utc().add(4, 'hours')) {
   document.body.classList.add('office-hours-soon')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/173/42659251-51e4a26a-85ed-11e8-82a0-1d9016eb0aa4.png)

This is a fix for the change in #135 that removed the check if office hours is already past for today.

🎩 @hiimbex @zeke 