### PR TITLE
community links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :jekyll_plugins do
   gem 'github-pages', versions['github-pages']
   gem 'jekyll-octicons'
   gem 'jekyll-readme-index'
+  gem 'jekyll-mentions'
   gem 'jemoji'
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -39,11 +39,12 @@ defaults:
       layout: docs
 
 plugins:
-  - jekyll-redirect-from
+  - jekyll-mentions
   - jekyll-octicons
-  - jekyll-sitemap
-  - jekyll-seo-tag
   - jekyll-readme-index
+  - jekyll-redirect-from
+  - jekyll-seo-tag
+  - jekyll-sitemap
   - jemoji
 
 branch: master

--- a/community.html
+++ b/community.html
@@ -81,13 +81,15 @@ links:
   </div>
 
   <div class="border-top container-md py-4">
-    {% for link in page.links %}
-    <div class="p-0 p-md-4 mb-4 mb-md-0">
-      {{ link.pretext }}:<br>
-      {% octicon {{ link.octicon }} class:"mr-2 text-gray" %}
-      <a href="{{ link.href }}">{{ link.title }}</a>
+    <div class="d-flex gutter flex-wrap">
+      {% for link in page.links %}
+      <div class="col-md-6 col-12 mb-4">
+        {{ link.pretext }}:<br>
+        {% octicon {{ link.octicon }} class:"mr-2 text-gray" %}
+        <a href="{{ link.href }}">{{ link.title }}</a>
+      </div>
+      {% endfor %}
     </div>
-    {% endfor %}
   </div>
 </div>
 

--- a/community.html
+++ b/community.html
@@ -4,6 +4,19 @@ title: Community
 office_hours_link: https://github.zoom.us/j/221410810
 redirect_from:
   - /contribute/
+links:
+- octicon: unmute
+  pretext: "Listen to the podcast with @hiimbex & @bdougie"
+  title: "Frontsize 105: Automating GitHub with Probot"
+  href: https://frontside.io/podcast/105-automating-github-with-probot/
+- octicon: unmute
+  pretext: "Listen to the podcast with @bkeepers & @hiimbex"
+  title: "The Changelog #264: Automating GitHub with Probot"
+  href: https://changelog.com/podcast/264
+- octicon: device-camera-video
+  pretext: "Watch the talk at GitHub Universe from @jbjonesjr"
+  title: "Extending with GitHub: easy integrations with Probot"
+  href: https://www.youtube.com/watch?v=AJXDdkd9U7M
 ---
 
 <div class="container-lg px-3 featurette">
@@ -67,19 +80,14 @@ redirect_from:
     </div>
   </div>
 
-  <div class="border-top container-md py-4 mx-auto d-block d-md-flex gutter-md">
-    <div class="col-12 col-md-6 mb-4 mb-md-0">
-      <div class="p-0 p-md-4">
-        {% octicon unmute class:"mr-2 text-gray" %}
-        Listen to The Changelog #264: <a class="text-bold" href="https://changelog.com/podcast/264">Automating GitHub with Probot</a>
-      </div>
+  <div class="border-top container-md py-4">
+    {% for link in page.links %}
+    <div class="p-0 p-md-4 mb-4 mb-md-0">
+      {{ link.pretext }}:<br>
+      {% octicon {{ link.octicon }} class:"mr-2 text-gray" %}
+      <a href="{{ link.href }}">{{ link.title }}</a>
     </div>
-    <div class="col-12 col-md-6">
-      <div class="p-0 p-md-4">
-        {% octicon device-camera-video class:"mr-2 text-gray" %}
-        Watch the talk at GitHub Universe: <a class="text-bold" href="https://www.youtube.com/watch?v=AJXDdkd9U7M">Extending with GitHub: easy integrations with Probot</a>
-      </div>
-    </div>
+    {% endfor %}
   </div>
 </div>
 


### PR DESCRIPTION
This adds frontmatter to the community page to make it easier to add links as new content becomes available that is relevant to the community.

@JasonEtco This could use some love if you have a few minutes

Fixes #214 

---

![](https://user-images.githubusercontent.com/173/42725573-62aebcd4-874b-11e8-80d7-3f767f93a33c.png)
