### PR TITLE
Use first screenshot for app pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,9 +12,13 @@
     <meta name="twitter:site" content="@ProbotTheRobot" />
     <meta property="twitter:card" content="summary_large_image" />
 
+    {% if page.screenshots %}
+    <meta property="og:image" content="{{ page.screenshots | first }}" />
+    {% else %}
     <meta property="og:image" content="{{ "/assets/card.png" | absolute_url }}" />
     <meta property="og:image:height" content="1280" />
     <meta property="og:image:width" content="630" />
+    {% endif %}
     <meta property="twitter:image:alt" content="{{ site.description }}" />
     <meta property="og:image:type" content="image/png" />
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,11 +13,11 @@
     <meta property="twitter:card" content="summary_large_image" />
 
     {% if page.screenshots %}
-    <meta property="og:image" content="{{ page.screenshots | first }}" />
+      <meta property="og:image" content="{{ page.screenshots | first }}" />
     {% else %}
-    <meta property="og:image" content="{{ "/assets/card.png" | absolute_url }}" />
-    <meta property="og:image:height" content="1280" />
-    <meta property="og:image:width" content="630" />
+      <meta property="og:image" content="{{ "/assets/card.png" | absolute_url }}" />
+      <meta property="og:image:height" content="1280" />
+      <meta property="og:image:width" content="630" />
     {% endif %}
     <meta property="twitter:image:alt" content="{{ site.description }}" />
     <meta property="og:image:type" content="image/png" />


### PR DESCRIPTION
This uses the first screenshot as the `og:image` (social card) for apps.

Fixes #83 