### PR TITLE
add Changelog Reminder app

### DIFF
--- a/_apps/changelog-reminder.md
+++ b/_apps/changelog-reminder.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog Reminder
-description: A GitHub app that reminds to update CHANGELOG.md.
+description: Reminds to update CHANGELOG.md.
 slug: changelog-reminder
 screenshots:
 - https://raw.githubusercontent.com/pverkhovskyi/changelog-reminder/master/docs/changelog-reminder.png

--- a/_apps/changelog-reminder.md
+++ b/_apps/changelog-reminder.md
@@ -7,7 +7,7 @@ screenshots:
 authors:
 - pverkhovskyi
 repository: pverkhovskyi/changelog-reminder
-host: https://changelog-reminder.herokuapp.com/
+host: https://changelog-reminder.herokuapp.com
 ---
 
 Changelog Reminder is a useful app for projects which maintain CHANGELOG.md. It comments on newly opened  pull requests when changes were not reflected in the changelog.

--- a/_apps/changelog-reminder.md
+++ b/_apps/changelog-reminder.md
@@ -1,0 +1,27 @@
+---
+title: Changelog Reminder
+description: A GitHub bot that reminds to update CHANGELOG.md.
+slug: changelog-reminder
+screenshots:
+- https://raw.githubusercontent.com/pverkhovskyi/changelog-reminder/master/docs/changelog-reminder.png
+authors:
+- pverkhovskyi
+repository: pverkhovskyi/changelog-reminder
+host: https://changelog-reminder.herokuapp.com/
+---
+
+Changelog Reminder is a useful bot for projects which maintain CHANGELOG.md. It comments on newly opened  pull requests when changes were not reflected in the changelog.
+
+## Usage
+
+1. Install the bot on the intended repositories. The app has **no access to your code**. It requires following permissions:
+  - **Read** access to metadata and single file `.github/config.yml`
+  - **Read** and **write** access to pull requests
+2. Add a `.github/config.yml` file that contains the contents you would like to reply within an `changelogReminderMessage`.
+
+```yml
+# Message to be posted when PRs don't update changelog
+changelogReminderMessage: >
+    Thanks for opening this pull request! All notable changes to this project should be documented in CHANGELOG.md. Please update it based on your changes.
+
+```

--- a/_apps/changelog-reminder.md
+++ b/_apps/changelog-reminder.md
@@ -1,6 +1,6 @@
 ---
 title: Changelog Reminder
-description: A GitHub bot that reminds to update CHANGELOG.md.
+description: A GitHub app that reminds to update CHANGELOG.md.
 slug: changelog-reminder
 screenshots:
 - https://raw.githubusercontent.com/pverkhovskyi/changelog-reminder/master/docs/changelog-reminder.png
@@ -10,11 +10,11 @@ repository: pverkhovskyi/changelog-reminder
 host: https://changelog-reminder.herokuapp.com/
 ---
 
-Changelog Reminder is a useful bot for projects which maintain CHANGELOG.md. It comments on newly opened  pull requests when changes were not reflected in the changelog.
+Changelog Reminder is a useful app for projects which maintain CHANGELOG.md. It comments on newly opened  pull requests when changes were not reflected in the changelog.
 
 ## Usage
 
-1. Install the bot on the intended repositories. The app has **no access to your code**. It requires following permissions:
+1. Install the app on the intended repositories. The app has **no access to your code**. It requires following permissions:
   - **Read** access to metadata and single file `.github/config.yml`
   - **Read** and **write** access to pull requests
 2. Add a `.github/config.yml` file that contains the contents you would like to reply within an `changelogReminderMessage`.


### PR DESCRIPTION
This adds [Changelog Reminder](https://github.com/pverkhovskyi/changelog-reminder) to the list of apps

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.

