### PR TITLE
Add probot-deploy to the app directory

### DIFF
--- a/_apps/Deploy
+++ b/_apps/Deploy
@@ -1,0 +1,19 @@
+---
+# A human-friendly name of your listing
+title: Deploy
+# A short description of what your app does
+description: Triggers a deployment event on GitHub based on pull request labels.
+# The slug of your hosted app on GitHub (https://github.com/apps/YOUR-SLUG)
+slug: probot-deploy
+# Include a few screenshots that show your app in action
+screenshots:
+- https://user-images.githubusercontent.com/2787414/44789192-3f4c1a00-ab9c-11e8-9093-353dfbe1bc1e.gif
+# The GitHub usernames of anyone who authored the app
+authors: [ helaili ]
+# The repository where the code is located
+repository: helaili/probot-deploy
+# The address where this app is deployed
+host: https://probot-deploy-dotcom.now.sh
+---
+
+This app uses GitHub's deployment API and triggers a deployment event when a matching label is applied to a Pull Request. 


### PR DESCRIPTION
##### Checklist

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers
- [x] Is original: for example, it does something not already done by an existing probot app
- [x] Has tests
- [x] Has documentation
- [x] Is open source
- [x] Has a license
- [x] Has a code of conduct
- [x] Has someone willing to at least minimally maintain them for the near future
