### PR TITLE
Update triage-new-issues.md

### DIFF
--- a/_apps/triage-new-issues.md
+++ b/_apps/triage-new-issues.md
@@ -9,9 +9,8 @@ screenshots:
 - https://i.imgur.com/fOp0Est.png
 - https://i.imgur.com/ldrHDzZ.png
 authors:
-- tunnckoCore
 - olstenlarck
-repository: tunnckoCore/triage-new-issues
+repository: tunnckoCoreLabs/triage-new-issues
 host: https://triage-new-issues.now.sh
 stars: 11
 updated: 2018-09-07 11:31:12 UTC


### PR DESCRIPTION
[This build failure](https://travis-ci.org/probot/probot.github.io/builds/426416288?utm_source=github_status&utm_medium=notification) appears to be caused by the `tunnckoCore` org changing it's name to `tunnckoCoreLabs`, where the code for this app lives. 

@olstenlarck I'd love a +1 on this change, but since it's actively breaking our build, I'll be merging it tomorrow if I don't hear from you.