### PR TITLE
Fix broken app slug

### DIFF
--- a/_apps/topissues.md
+++ b/_apps/topissues.md
@@ -6,7 +6,7 @@ title: Top Issues
 description: Labels issues with the most "+1" emoji reactions
 
 # The slug of your hosted app on GitHub (https://github.com/apps/YOUR-SLUG)
-slug: top-issues
+slug: top-issues-bot
 
 # Include a few screenshots that show your app in action
 screenshots: 


### PR DESCRIPTION
Fixing broken app slug. Should be top-issues-bot. Add to GitHub link at https://probot.github.io/apps/topissues/ isn't working because of the broken slug.

Should be https://github.com/apps/top-issues-bot/installations/new.

Is currently, https://github.com/apps/top-issues/installations/new.ew.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/probot/probot.github.io/blob/master/CONTRIBUTING.md

App Review Process: https://github.com/probot/probot.github.io/blob/master/.github/app-review-process.md
-->

##### Checklist
<!-- Be sure to replace yourURLhere for relevant links. Additionally, update anything in {braces}. For completed items, change [ ] to [x]. -->

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers: {explain the action here}
- [x] Is original: for example, it does something not already done by an existing Probot app
- [x] [Has tests](yourURLhere)
- [x] [Has documentation](yourURLhere)
- [x] [Is open source](yourURLhere)
- [x] [Has a license](yourURLhere)
- [x] [Has a code of conduct](yourURLhere)
- [x] Has someone willing to at least minimally maintain them for the near future: {your maintainer's name}


-----
[View rendered _apps/topissues.md](https://github.com/adamzolyak/probot.github.io/blob/adamzolyak-patch-2/_apps/topissues.md)