### PR TITLE
Add Pull Request Size

### DIFF
--- a/_apps/pull-request-size.md
+++ b/_apps/pull-request-size.md
@@ -1,0 +1,30 @@
+---
+title: Pull Request Size
+description: Applies `size/*` labels to Pull Requests based on the total lines of code changed (additions and deletions).
+slug: pull-request-size
+screenshots:
+- https://user-images.githubusercontent.com/4740147/47858607-d7e05f80-ddc2-11e8-97d9-247033cc9a12.png
+authors: [ noqcks ]
+repository: noqcks/pull-request-size
+host: https://pull-request-size.herokuapp.com
+---
+
+# Pull Request Size
+
+Pull Request Size is a GitHub App that applies `size/*` labels to Pull Requests based on the total lines of code changed (additions and deletions).
+
+
+<img width="767" alt="screen shot 2018-11-01 at 10 42 27 am" src="https://user-images.githubusercontent.com/4740147/47858607-d7e05f80-ddc2-11e8-97d9-247033cc9a12.png">
+
+## Sizing
+
+| Name | Description |
+| ---- | ----------- |
+| <a id="size/XS" href="#size/XS">`size/XS`</a> | Denotes a PR that changes 0-9 lines. |
+| <a id="size/S" href="#size/S">`size/S`</a> | Denotes a PR that changes 10-29 lines. |
+| <a id="size/M" href="#size/M">`size/M`</a> | Denotes a PR that changes 30-99 lines. |
+| <a id="size/L" href="#size/L">`size/L`</a> | Denotes a PR that changes 100-499 lines. |
+| <a id="size/XL" href="#size/XL">`size/XL`</a> | Denotes a PR that changes 500-999 lines. |
+| <a id="size/XXL" href="#size/XXL">`size/XXL`</a> | Denotes a PR that changes 1000+ lines. |
+
+


### PR DESCRIPTION
This PR adds the probot-made app Pull Request Size, which will apply size labels to a users Pull Request based on how large the pull request is.

##### Checklist

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers: applies labels to Pull Requests 
- [x] Is original: for example, it does something not already done by an existing Probot app
- [x] [Has tests](https://github.com/noqcks/pull-request-size/tree/master/tests)
- [x] [Has documentation](https://github.com/noqcks/pull-request-size/blob/master/README.md)
- [x] [Is open source](https://github.com/noqcks/pull-request-size)
- [x] [Has a license](https://github.com/noqcks/pull-request-size/blob/master/LICENSE)
- [x] [Has a code of conduct](https://github.com/noqcks/pull-request-size/blob/master/CODE_OF_CONDUCT.md)
- [x] Has someone willing to at least minimally maintain them for the near future: Benji Visser <benny@noqcks.io>


-----
[View rendered _apps/pull-request-size.md](https://github.com/noqcks/probot.github.io/blob/patch-1/_apps/pull-request-size.md)