### PR TITLE
Link to the Probot members in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
         </span>
         <a href="https://twitter.com/ProbotTheRobot" class="twitter-follow-button" data-size="large" data-show-screen-name="false" data-show-count="false">Follow @ProbotTheRobot</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
       </p>
-      <p>{% octicon code %} with {% octicon heart %} by <a class="text-gray-light" href="https://github.com/orgs/probot/people">the Probot team</a></p>
+      <p>{% octicon code %} with {% octicon heart %} by <a class="text-gray-light" href="https://github.com/probot">the Probot community</a></p>
       <p style="opacity: 0.5">
         <span class="mr-2">Code licensed <a class="text-inherit" href="https://github.com/probot/probot/blob/master/LICENSE">ISC</a></span>
         <span>Docs licensed <a class="text-inherit" href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a></span>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
         </span>
         <a href="https://twitter.com/ProbotTheRobot" class="twitter-follow-button" data-size="large" data-show-screen-name="false" data-show-count="false">Follow @ProbotTheRobot</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
       </p>
-      <p>{% octicon code %} with {% octicon heart %} by <a class="text-gray-light" href="https://twitter.com/bkeepers">@bkeepers</a></p>
+      <p>{% octicon code %} with {% octicon heart %} by <a class="text-gray-light" href="https://github.com/orgs/probot/people">the Probot team</a></p>
       <p style="opacity: 0.5">
         <span class="mr-2">Code licensed <a class="text-inherit" href="https://github.com/probot/probot/blob/master/LICENSE">ISC</a></span>
         <span>Docs licensed <a class="text-inherit" href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a></span>


### PR DESCRIPTION
We've been maintaining Probot and the various projects surrounding it as a group for about a year now - this change updates the footer of the website to reflect that. @bkeepers, we still ❤️ you - hopefully we can all recognize this tiny change as a big reflection of where the project has come.

I've changed the footer to link to [the Member list of the Probot org](https://github.com/orgs/probot/people), but I'm wondering what y'all think about linking to the contributors list of the `probot/probot` repo? My concern with that is that a lot of work goes into other repos (like this one, Smee, individual apps like Stale/Settings) - but I'm interested in your thoughts @probot/maintainers!