### PR TITLE
Add handlebar templates to App directory

### DIFF
--- a/_apps/handlebar-templates.md
+++ b/_apps/handlebar-templates.md
@@ -1,0 +1,17 @@
+---
+title: Handlebar Templates
+description: Issue body and pull request's body through handlebars to generate new bodies
+slug: handlebar-templates
+screenshots:
+- https://marketplace-screenshots.githubusercontent.com/4741/9cc94800-a642-11e9-9e44-3a6791c11e3b
+- https://marketplace-screenshots.githubusercontent.com/4741/a2269280-a642-11e9-819b-e0afe442db67
+- https://marketplace-screenshots.githubusercontent.com/4741/a488ec80-a642-11e9-85d4-f74be5aa0f90
+authors:
+- cyberhck
+repository: fossapps/Handlebars-Issue-and-Pull-Requests
+stars: 0
+host: https://handlebar-templates.cyberhck.now.sh
+---
+
+One example usage is to add link to build for this issue, or link to docs built for this PR
+For instance, you build a preview of your app on each pr which would be hosted on {{id}}-staging.example.com here you're using handlebars to manage this.


### PR DESCRIPTION
##### Checklist

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [ ] All comments in frontmatter need to be removed. (**Don't know what this is**)
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers: {I build my component documentation and put it on github pages, each pr is built and kept under the pull request number directory, this way I can generate this link, I can also add a link to build if I wanted to}
- [x] Is original: for example, it does something not already done by an existing Probot app
- [x] [Has tests](https://github.com/fossapps/Handlebars-Issue-and-Pull-Requests/tree/master/src)
- [x] [Has documentation, since it's typescript I'd say code is documentation](https://github.com/fossapps/Handlebars-Issue-and-Pull-Requests/tree/master/src)
- [x] [Is open source](https://github.com/fossapps/Handlebars-Issue-and-Pull-Requests)
- [x] [Has a license](https://github.com/fossapps/Handlebars-Issue-and-Pull-Requests/blob/master/LICENSE.md)
- [x] [Has a code of conduct](https://github.com/fossapps/Handlebars-Issue-and-Pull-Requests/blob/master/CODE_OF_CONDUCT.md)
- [x] Has someone willing to at least minimally maintain them for the near future: {Nishchal Gautam (@cyberhck)}


-----
[View rendered _apps/handlebar-templates.md](https://github.com/cyberhck/probot.github.io/blob/patch-1/_apps/handlebar-templates.md)