### PR TITLE
Update host for issuelabeler

### DIFF
--- a/_apps/issuelabeler.md
+++ b/_apps/issuelabeler.md
@@ -7,7 +7,7 @@ screenshots:
 authors:
 - riyadhalnur
 repository: riyadhalnur/issuelabeler
-host: https://1th3h69bkc.execute-api.ap-southeast-1.amazonaws.com/production
+host: https://issuelabeler.verticalaxisbd.com
 stars: 8
 updated: 2019-07-19 11:51:07 UTC
 installations: 27


### PR DESCRIPTION
Update host for `issuelabeler` due to failing CI as mentioned on https://github.com/probot/probot.github.io/issues/293. Temporary since the stats endpoint will not work until upstream module is fixed.

-----
[View rendered _apps/issuelabeler.md](https://github.com/riyadhalnur/probot.github.io/blob/patch-1/_apps/issuelabeler.md)