### PR TITLE
remove contributors section

### DIFF
--- a/_apps/dep.md
+++ b/_apps/dep.md
@@ -58,14 +58,6 @@ For best results, enable branch protection (in the repository's settings) and re
 
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-
-<table>
-<tr>
-<th align="center"><a href="https://ahmed.sd"><img src="https://avatars1.githubusercontent.com/u/12673605?v=4" width="100px;" style="max-width:100%;"><br><sub><b>Ahmed T. Ali</b></sub></a><br><a href="https://goo.gl/sJKF5H" title="Blogposts"><g-emoji alias="memo" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4dd.png" ios-version="6.0"><img class="emoji" alt=":memo:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4dd.png"></g-emoji></a> <a href="https://github.com/z0al/dep/commits?author=z0al" title="Code"><g-emoji alias="computer" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4bb.png" ios-version="6.0"><img class="emoji" alt=":computer:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4bb.png"></g-emoji></a> <a href="https://github.com/z0al/dep/commits?author=z0al" title="Documentation"><g-emoji alias="book" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4d6.png" ios-version="6.0"><img class="emoji" alt=":book:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4d6.png"></g-emoji></a> <a href="https://github.com/z0al/dep/commits?author=z0al" title="Tests"><g-emoji alias="warning" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/26a0.png" ios-version="6.0"><img class="emoji" alt=":warning:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/26a0.png"></g-emoji></a></th>
-<th align="center"><a href="https://github.com/JasonEtco"><img src="https://avatars1.githubusercontent.com/u/10660468?v=4" width="100px;" style="max-width:100%;"><br><sub><b>Jason Etcovitch</b></sub></a><br><a href="https://twitter.com/JasonEtco" title="Answering Questions"><g-emoji alias="speech_balloon" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4ac.png" ios-version="6.0"><img class="emoji" alt=":speech_balloon:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f4ac.png"></g-emoji></a> <a href="https://github.com/probot/ideas/issues/1" title="Ideas, Planning, &amp; Feedback"><g-emoji alias="thinking" fallback-src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f914.png" ios-version="9.1"><img class="emoji" alt=":thinking:" height="20" width="20" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f914.png"></g-emoji></a></th>
-</tr></table>
-
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!
 
 ## Credits


### PR DESCRIPTION
- contributors can be found in dep's repository
- no matter what we do, not everyone will come back to this repo once their app is approved and merged, so if build fails, we'll remove it first, then they can provide a fix
- this repo shouldn't fail because someone didn't care
- we should probably add this in some places.
on #302 I've discussed about cleaning up, we should also do this, if something fails, it simply goes away.