### PR TITLE
Separate HTML proofing from app tests

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 case "$TRAVIS_EVENT_TYPE" in
-  cron ) script/remote-sync;;
+  cron ) script/remote-sync; script/site-test;;
   *    ) script/test;;
 esac

--- a/script/site-test
+++ b/script/site-test
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+script/build
+script/html-proofer

--- a/script/test
+++ b/script/test
@@ -3,5 +3,3 @@
 set -e
 
 ruby test/*_test.rb
-script/build
-script/html-proofer


### PR DESCRIPTION
Moves HTML proofing of site content to the cron part of the CI tests since a failure there is blocking the on-boarding process of new apps (also see discussion in https://github.com/probot/probot.github.io/pull/300).