### PR TITLE
feat: added Semantic PR Title app file

### DIFF
--- a/_apps/semantic-pr-title.md
+++ b/_apps/semantic-pr-title.md
@@ -1,0 +1,39 @@
+---
+# A human-friendly name of your listing
+title: Semantic PR Title
+# A short description of what your app does
+description: Verifies PR title complies with Angular commit convention standard (or custom regex).
+# The slug of your hosted app on GitHub (https://github.com/apps/YOUR-SLUG)
+slug: semantic-pr-title
+# Include a few screenshots that show your app in action
+screenshots:
+- https://marketplace-screenshots.githubusercontent.com/5213/60c9af00-da06-11e9-92a1-f5190f364574?auto=webp&format=jpeg&width=670
+- https://marketplace-screenshots.githubusercontent.com/5213/6aebad80-da06-11e9-858b-a6d7a6a051e1?auto=webp&format=jpeg&width=670
+# The GitHub usernames of anyone who authored the app
+authors: [ coleHafner ]
+# The repository where the code is located
+repository: coleHafner/semantic-pr-title
+# The address where this app is deployed
+host: https://colehafner-pr-title-linter-1.glitch.me/probot
+---
+
+# Semantic PR Title
+
+> A GitHub App built with [Probot](https://github.com/probot/probot) that enforces your PR title to match a user defined regex.
+
+## Config
+Add a file @ `.github/semantic-pr-title.yml` with the following:
+
+```
+REGEX: <your regex here>
+```
+The default regex enforces the [angular commit convention](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines) (first line) on your PR title: `(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\s]+\\))?(:\\s)([a-z0-9\\s]+)`
+
+Note that the regex is a string and `\` must be escaped. 
+
+
+## Usage
+This app is [hosted on Glitch](https://colehafner-pr-title-linter-1.glitch.me) and available on [the GitHub marketplace](https://github.com/marketplace/semantic-pr-title).
+
+
+_Docs last updated on 9/23/2019. See [README](https://github.com/coleHafner/semantic-pr-title#config) here for most up-to-date docs._


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/probot/probot.github.io/blob/master/CONTRIBUTING.md

App Review Process: https://github.com/probot/probot.github.io/blob/master/.github/app-review-process.md
-->

##### Checklist
<!-- Be sure to replace yourURLhere for relevant links. Additionally, update anything in {braces}. For completed items, change [ ] to [x]. -->

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.

- [ ] All comments in frontmatter need to be removed.
> frontmatter? 

- [x] Performs a useful action through the GitHub API that solves an existing problem for developers: {explain the action here}

- [x] Is original: for example, it does something not already done by an existing Probot app
> There's [another app](https://github.com/probot/probot.github.io/blob/master/_apps/semantic-pull-requests.md) that does something similar, but I could not get it to work for my org/private repo. Mine works differently, as it only focuses on the PR title and uses a regex instead of commit lint. It's more flexible in that way since it could be used for anything that can be validated with a regex. 

- [x] [Has tests](https://github.com/coleHafner/semantic-pr-title/blob/master/test/index.test.js)
- [x] [Has documentation](https://github.com/coleHafner/semantic-pr-title#config)
- [x] [Is open source](https://github.com/coleHafner/semantic-pr-title)
- [x] [Has a license](https://github.com/coleHafner/semantic-pr-title/blob/master/LICENSE)
- [x] [Has a code of conduct](https://github.com/coleHafner/semantic-pr-title/blob/master/CODE_OF_CONDUCT.md)
- [x] Has someone willing to at least minimally maintain them for the near future: [coleHafner](https://github.com/coleHafner)


-----
[View rendered _apps/semantic-pr-title.md](https://github.com/coleHafner/probot.github.io/blob/patch-1/_apps/semantic-pr-title.md)