### PR TITLE
Set probot/maintainers as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @JasonEtco
+* @probot/maintainers


### PR DESCRIPTION
I shouldn't be the sole CODEOWNER for this repo - this updates the file to use the whole `@probot/maintainers` team.