### PR TITLE
add check group app

### DIFF
--- a/_apps/check-group.md
+++ b/_apps/check-group.md
@@ -1,0 +1,53 @@
+---
+title: Check Group
+description: Groups CI checks based on sub-projects for monorepo.
+slug: check-group
+screenshots:
+- https://github.com/tianhaoz95/approveman/raw/master/docs/asset/screenshots/approval.png
+- https://github.com/tianhaoz95/approveman/raw/master/docs/asset/screenshots/check_status.png
+authors:
+- tianhaoz95
+repository: tianhaoz95/check-group
+host: https://check-group.herokuapp.com
+stars: 0
+updated: 2020-09-22 00:28:41 UTC
+installations: 1
+organizations:
+- tianhaoz95
+---
+
+ApproveMan is a GitHub app that helps approve pull requests with safe changes.
+
+> This is especially useful for protected branches.
+
+## Motivation
+
+To maintain the health of repositories, it's important to set up review requirements and continuous integration to make sure every pull request that goes in is good.
+
+For example, GitHub provides "protected branches" as a way to put hard requirements including passing checks and code review approvals on incoming pull requests.
+
+However, not all pull requests require human attention.
+
+For example, it's reasonable for a repository to set up a location with a user's GitHub ID like `[project_root]/playground/tianhaoz95` to allow developers add quick experiments that they want to keep a record and share with the team.
+
+In this case, if I want to add some notes in `[project_root]/playground/tianhaoz95/my-note.md`, there is no reason to ask another developer to review the change.
+
+## Usage
+
+You can configure the behavior by adding rules into `.github/approveman.yml`.
+
+Here is an example that, given that my GitHub ID is `tianhaoz95`, approves all the changes that go into `playground/tianhaoz95` and `docs/personal/tianhaoz95`:
+
+```yml
+ownership_rules:
+  directory_matching_rules:
+    - name: personal projects in experimental
+      path: playground/{{username}}/**/*
+    - name: personal documentation
+      path: docs/personal/{{username}}/**/*
+```
+
+Note:
+
+-   The default config contains `playground/{{username}}/**/*` if no config file is provided in the repository.
+-   All pull requests that modify files within `.github` the directory is denied regardless of the rules in the configuration for safety.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/probot/probot.github.io/blob/master/CONTRIBUTING.md

App Review Process: https://github.com/probot/probot.github.io/blob/master/.github/app-review-process.md
-->

##### Checklist
<!-- Be sure to replace yourURLhere for relevant links. Additionally, update anything in {braces}. For completed items, change [ ] to [x]. -->

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers:

GitHub's protected branch provides a way to specify required CI checks for pull request merging.

GitHub Actions allows users to only run tests for matching paths. For monorepo projects, you can trigger checks based on which sub-projects are touched.

However, there seems to be a gap where, although GitHub Actions allow me to run only the checks I need, protected branch doesn't let me define the expected checks based on paths (or sub-projects).

This app lets users define expected CI checks based on sub-projects. When a pull request opens, it collects all the expected CI checks based on which sub-projects the pull request is touching and opens one more CI check that represents whether all expected checks has passed.

With this new CI check, protected branch can rely solely on this CI. In this way, developers won't have to wait for a Bazel rebuild when only a markdown is changed.

- [x] Is original: for example, it does something not already done by an existing Probot app

I went through the list and didn't find anything similar. Although it might be achievable with the combination of a ton of other tools/apps, it's nice to have a out-of-box solution I think.

- [x] [Has tests](https://github.com/tianhaoz95/check-group/blob/master/test/index.test.ts (integration test example), https://github.com/tianhaoz95/check-group/blob/master/src/utils/satisfy_expected_checks.test.ts (unit test example))
- [x] [Has documentation](https://tianhaoz.com/check-group)
- [x] [Is open source](https://github.com/tianhaoz95/check-group)
- [x] [Has a license](https://github.com/tianhaoz95/check-group/blob/master/LICENSE)
- [x] [Has a code of conduct](https://github.com/tianhaoz95/check-group/blob/master/CODE_OF_CONDUCT.md)
- [x] Has someone willing to at least minimally maintain them for the near future: @tianhaoz95 


-----
[View rendered _apps/check-group.md](https://github.com/tianhaoz95/probot.github.io/blob/chore/add-check-group/_apps/check-group.md)