### PR TITLE
Prettifier: Remove link from description

### DIFF
--- a/_apps/prettifier.md
+++ b/_apps/prettifier.md
@@ -1,6 +1,6 @@
 ---
 title: Prettifier
-description: Prettifier keeps your repository content formatted using [https://prettier.io](Prettier).
+description: Prettifier keeps your repository content formatted using Prettier.
 slug: prettifier
 screenshots:
 - https://raw.githubusercontent.com/kevgo/prettifier/master/website/website/static/img/screenshot_annotated_small.gif


### PR DESCRIPTION
Markdown links don't render properly, hence removing the link.


##### Checklist
<!-- Be sure to replace yourURLhere for relevant links. Additionally, update anything in {braces}. For completed items, change [ ] to [x]. -->

- [x] If you're adding a listing for your app, be sure your app is in the `/_apps/` folder before opening this Pull Request.
- [x] All comments in frontmatter need to be removed.
- [x] Performs a useful action through the GitHub API that solves an existing problem for developers: {explain the action here}
- [x] Is original: for example, it does something not already done by an existing Probot app
- [x] Has tests
- [x] [Has documentation](https://www.prettifier.io)
- [x] [Is open source](https://github.com/kevgo/prettifier)
- [x] [Has a license](https://github.com/kevgo/prettifier/blob/master/LICENSE)
- [x] [Has a code of conduct](https://github.com/kevgo/prettifier/blob/master/CODE_OF_CONDUCT.md)
- [x] Has someone willing to at least minimally maintain them for the near future: @kevgo 


-----
[View rendered _apps/prettifier.md](https://github.com/kevgo/probot.github.io/blob/patch-1/_apps/prettifier.md)