### PR TITLE
Use valid ormatting for repository

### DIFF
--- a/_apps/organization-workflows.md
+++ b/_apps/organization-workflows.md
@@ -12,7 +12,7 @@ screenshots:
 # The GitHub usernames of anyone who authored the app
 authors: [ svanboxel ]
 # The repository where the code is located
-repository: SvanBoxel/organization-workflows/
+repository: SvanBoxel/organization-workflows
 # The address where this app is deployed
 host: https://organization-workflows-bot.azurewebsites.net/
 ---


### PR DESCRIPTION
Cronjob is failing because of a backslash after the repository name:
<img width="1118" alt="Screenshot 2021-01-18 at 13 03 34" src="https://user-images.githubusercontent.com/24505883/104913374-cbd61d80-598d-11eb-900b-76e5bcb15608.png">

Removed the backslash.
