### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
+          cache: npm
 
       - name: Cache yarn packages
         uses: actions/cache@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,7 +2,7 @@ name: Sync app data
 
 on:
   schedule:
-    - cron:  '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   build:
@@ -14,7 +14,8 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: "16"
+          cache: npm
 
       - name: Cache yarn packages
         uses: actions/cache@v2
@@ -40,5 +41,5 @@ jobs:
         uses: davidolrik/push@b88b2c57f3a4c23bf2abf091c319e77088dd0172
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          message: 'chore: Sync data'
+          message: "chore: Sync data"
           branch: ${{ env.default_branch }}


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
