### PR TITLE
Sort by stars, high to low

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -8,7 +8,7 @@ title: Featured Apps
     <h1 class="h2">{{ page.title }}</h1>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = collections.apps | sort: 'data.installations' | reverse %}
+      {% assign apps = collections.apps | sort: 'data.stars' | reverse %}
       {% for app in apps %}
         {% include "app" app: app.data %}
       {% endfor %}

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: default.liquid
     </p>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = collections.apps | sort: 'installations' | reverse %} {% for app
+      {% assign apps = collections.apps | sort: 'stars' | reverse %} {% for app
       in apps limit:6 %} {% include "app" app: app.data %} {% endfor %}
     </div>
 


### PR DESCRIPTION
Since the installation count was removed in #375 the sorting defaulted to reversed alphabetically, which does not make sense. This PR changes the sorting of apps on the landing and Apps pages to number of stars (high to low).