### PR TITLE
Sort by stars high to low

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -8,7 +8,7 @@ title: Featured Apps
     <h1 class="h2">{{ page.title }}</h1>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = collections.apps | sort: 'data.installations' | reverse %}
+      {% assign apps = collections.apps | sort: 'data.stars' | reverse %}
       {% for app in apps %}
         {% include "app" app: app.data %}
       {% endfor %}

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: default.liquid
     </p>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = collections.apps | sort: 'installations' | reverse %} {% for app
+      {% assign apps = collections.apps | sort: 'stars' | reverse %} {% for app
       in apps limit:6 %} {% include "app" app: app.data %} {% endfor %}
     </div>
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: default.liquid
     </p>
 
     <div class="d-md-flex flex-wrap gutter flex-auto">
-      {% assign apps = collections.apps | sort: 'stars' | reverse %} {% for app
+      {% assign apps = collections.apps | sort: 'data.stars' | reverse %} {% for app
       in apps limit:6 %} {% include "app" app: app.data %} {% endfor %}
     </div>
 


### PR DESCRIPTION
Follow-up PR to #377 

I still see the ordering of Apps on the [landing page](https://probot.github.io/) is not by stars. When I run the site locally with `yarn watch` the ordering _is_ based on stars (high to low). This PR puts the `data` prefix in the sort command. If that does not help I do not understand why it works in my development environment but not in production.