### PR TITLE
Replace slack button

### DIFF
--- a/community.html
+++ b/community.html
@@ -16,9 +16,9 @@ redirect_from:
   <div class="text-center my-6">
     <a
       class="btn btn-outline d-inline-block mb-1 mb-md-0 mr-0 mr-md-3"
-      href="https://probot-slackin.herokuapp.com/"
+      href="https://github.com/probot/probot/discussions"
     >
-      Chat on Slack
+      GitHub Discussions
     </a>
 
     <a


### PR DESCRIPTION
The Probot app for auto-inviting users to Slack is offline. We'd like to encourage users to move to GitHub discussions, so this PR removes the "Chat on Slack" button. This will also have the effect of no new users being able to be auto-invited to Slack to help stop some of the spammy users we've been getting.