### PR TITLE
Remove host for in-solidarity.md

### DIFF
--- a/_apps/in-solidarity.md
+++ b/_apps/in-solidarity.md
@@ -7,7 +7,6 @@ screenshots:
 authors:
   - jpoehnelt
 repository: jpoehnelt/in-solidarity-bot
-host: https://bot.in-solidarity.dev
 stars: 33
 updated: 2022-10-10 16:42:13 UTC
 ---


### PR DESCRIPTION
The host seems to be no longer existing, but the bot still exists.
