### PR TITLE
fix: update screenshot urls to be rendered correctly in issue-assigner

### DIFF
--- a/_apps/issue-assigner.md
+++ b/_apps/issue-assigner.md
@@ -3,10 +3,10 @@ title: Issue Assigner
 description: A bot for managing issue assignments
 slug: issue-assigner
 screenshots:
-  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/maintainer-opened-issue.jpg
-  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/claim-issue.jpg
-  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/have-existing-issues.jpg
-  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/abandon-issue.jpg
+  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/maintainer-opened-issue.jpg?raw=true
+  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/claim-issue.jpg?raw=true
+  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/have-existing-issues.jpg?raw=true
+  - https://github.com/Varun-Kolanu/issue-assigner/blob/main/assets/abandon-issue.jpg?raw=true
 authors:
   - Varun-Kolanu
 repository: Varun-Kolanu/issue-assigner


### PR DESCRIPTION
The images in the issue-assigner app were not working before. Sorry for that.

![image](https://github.com/probot/probot.github.io/assets/112728411/3c7d12a2-7bc9-415c-9ff6-60cf520e1802)

It is now being rendered correctly:

![image](https://github.com/probot/probot.github.io/assets/112728411/9f5bf57c-d5f3-4a25-8089-73d765b55177)
